### PR TITLE
Add TradingView execution lane bot

### DIFF
--- a/TradingView-GMOcoin-bot-exec-lane-v1/.gitignore
+++ b/TradingView-GMOcoin-bot-exec-lane-v1/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+.env
+runtime.db
+*.log

--- a/TradingView-GMOcoin-bot-exec-lane-v1/README.md
+++ b/TradingView-GMOcoin-bot-exec-lane-v1/README.md
@@ -1,0 +1,190 @@
+# TradingView-GMOcoin-bot-exec-lane-v1
+
+最小構成の TradingView → GMOコイン（レバレッジ）自動売買ボットです。TradingView の Webhook から受信したシグナルに基づき、GMO コインに対して成行 ENTRY / 成行 CLOSE（全量クローズ）を発注します。FastAPI + pybotters による非同期実装で、Docker Compose で即時起動できます。
+
+## 機能概要
+
+- `POST /webhook` に TradingView からの JSON を受信し、GMO コインへ成行注文を発注
+- 建玉が存在する状態での新規 ENTRY は `ENTRY_POLICY=ignore` により無視（通知なし）
+- `event_id` を SQLite で短期保存し、600 秒間の冪等性を担保
+- WebSocket (`positionSummaryEvents`, `executionEvents`) で建玉と約定を監視
+- Discord Webhook へ ENTRY / CLOSE 成功と失敗を通知
+- `/healthz` `/status` によるヘルスチェック・稼働状況把握
+- Docker（python:3.11-slim）ベース、uvloop（Linux）の利用
+
+## ディレクトリ構成
+
+```
+TradingView-GMOcoin-bot-exec-lane-v1/
+├─ docker-compose.yml
+├─ README.md
+├─ .gitignore
+├─ config/
+│  └─ .env.example
+├─ exec-lane/
+│  ├─ Dockerfile
+│  ├─ requirements.txt
+│  ├─ app.py
+│  ├─ notify.py
+│  ├─ storage.py
+│  └─ gmo.py
+└─ kuma-data/
+   └─ .gitkeep
+```
+
+## セットアップ手順
+
+1. **環境変数ファイルを作成**
+
+   `config/.env.example` をコピーし、API キーなどを設定します。
+
+   ```bash
+   cp config/.env.example config/.env
+   vi config/.env
+   ```
+
+2. **Docker Compose を起動**
+
+   ```bash
+   docker compose up -d
+   ```
+
+   `exec-lane` コンテナが起動し、`http://127.0.0.1:8080/healthz` が `{"status":"ok"}` を返せば準備完了です。
+
+## TradingView アラート設定
+
+TradingView のアラート本文には以下の JSON をそのまま貼り付けてください。`token` と `symbol` は `.env` の設定と一致させます。
+
+### ENTRY
+
+```json
+{
+  "token": "SECRETxxyyzz",
+  "event_id": "{{alert_id}}",
+  "ts": "{{timenow}}",
+  "mode": "ENTRY",
+  "symbol": "BTC_JPY",
+  "side": "BUY",
+  "size": 0.04
+}
+```
+
+### CLOSE
+
+```json
+{
+  "token": "SECRETxxyyzz",
+  "event_id": "{{alert_id}}",
+  "ts": "{{timenow}}",
+  "mode": "CLOSE",
+  "symbol": "BTC_JPY"
+}
+```
+
+## エンドポイント
+
+| メソッド | パス       | 説明 |
+|----------|------------|------|
+| GET      | `/healthz` | アプリケーションおよび SQLite の軽量チェック |
+| GET      | `/status`  | 建玉数量、最終イベント、WS ステータス、再試行統計を JSON で返却 |
+| POST     | `/webhook` | TradingView からの Webhook 受付。ENTRY / CLOSE を実行 |
+
+## スモークテスト
+
+`.env` の `WEBHOOK_TOKEN` に合わせて、以下の `curl` コマンドで疎通確認ができます。時刻 `ts` は ±60 秒以内の値に差し替えてください。
+
+### ENTRY リクエスト
+
+```bash
+curl -iS http://127.0.0.1:8080/webhook \
+ -H "Content-Type: application/json" \
+ --data-binary '{
+  "token":"SECRETxxyyzz",
+  "event_id":"dev-ENTRY-001",
+  "ts":"2025-09-24T00:00:00Z",
+  "mode":"ENTRY",
+  "symbol":"BTC_JPY",
+  "side":"BUY",
+  "size":0.04
+ }'
+```
+
+### CLOSE リクエスト
+
+```bash
+curl -iS http://127.0.0.1:8080/webhook \
+ -H "Content-Type: application/json" \
+ --data-binary '{
+  "token":"SECRETxxyyzz",
+  "event_id":"dev-CLOSE-001",
+  "ts":"2025-09-24T00:01:00Z",
+  "mode":"CLOSE",
+  "symbol":"BTC_JPY"
+ }'
+```
+
+## 運用チェックリスト
+
+- **時刻同期**: `chrony` などでサーバ時刻を NTP 同期（`ts` ±60 秒チェックを通すため）
+- **公開設定**: Cloudflared / Caddy などで `/webhook` を HTTPS 公開（本アプリは HTTP バインド）
+- **監視**: `/healthz` を Uptime Kuma 等で監視。必要なら `kuma-data/` をマウント
+- **GMO API 制限**: 429/5xx を監視し、レートリミットを踏んでいないか確認
+
+## トラブルシュート
+
+| 症状 | ログ/通知 | 対応策 |
+|------|-----------|--------|
+| `timestamp skew too large` | `/webhook` 400 | サーバ時刻と TradingView 時刻を確認。NTP 再同期 |
+| `duplicate event` | `/webhook` 応答 `{"status":"duplicate"}` | `event_id` が 600 秒以内に重複。TradingView の alert_id をユニークにする |
+| Discord に ERROR 通知 | `code=ERR-5010` 等 | GMO API エラーコードを確認。API キー/シークレット、ポジション上限、証拠金をチェック |
+| `close failed` | Discord ERROR | ポジション数量超過。`market_close_all` が自動縮小するが、ポジション照会と数量を確認 |
+| WebSocket 切断 | `/status` の `ws_connected=false` | ネットワーク状況と API 接続を確認。再接続は自動実行 |
+
+## 主要設定項目
+
+`.env` で指定する主要項目:
+
+- `WEBHOOK_TOKEN`: TradingView からの共有シークレット
+- `GMO_API_KEY` / `GMO_API_SECRET`: GMO コイン API 認証情報
+- `ALLOWED_SYMBOLS`: 許可するシンボル（カンマ区切り）。標準は `BTC_JPY`
+- `MAX_SKEW_SECONDS`: `ts` の許容ずれ秒数（標準 60 秒）
+- `QTY_STEP` / `MIN_QTY`: 発注数量の丸め・最小数量
+- `NOTIFY_DISCORD_WEBHOOK_URL`: Discord 通知先
+
+## 起動手順まとめ
+
+1. `config/.env` を用意
+2. `docker compose up -d`
+3. `curl http://127.0.0.1:8080/healthz`
+
+## スモークテスト再掲
+
+ENTRY:
+
+```bash
+curl -iS http://127.0.0.1:8080/webhook \
+ -H "Content-Type: application/json" \
+ --data-binary '{
+  "token":"SECRETxxyyzz",
+  "event_id":"dev-ENTRY-001",
+  "ts":"2025-09-24T00:00:00Z",
+  "mode":"ENTRY",
+  "symbol":"BTC_JPY",
+  "side":"BUY",
+  "size":0.04
+ }'
+```
+
+CLOSE:
+
+```bash
+curl -iS http://127.0.0.1:8080/webhook \
+ -H "Content-Type: application/json" \
+ --data-binary '{
+  "token":"SECRETxxyyzz",
+  "event_id":"dev-CLOSE-001",
+  "ts":"2025-09-24T00:01:00Z",
+  "mode":"CLOSE",
+  "symbol":"BTC_JPY"
+ }'
+```

--- a/TradingView-GMOcoin-bot-exec-lane-v1/config/.env.example
+++ b/TradingView-GMOcoin-bot-exec-lane-v1/config/.env.example
@@ -1,0 +1,25 @@
+# TradingView webhook shared secret
+WEBHOOK_TOKEN=SECRETxxyyzz
+
+# GMO Coin API credentials
+GMO_API_KEY=your_gmo_api_key
+GMO_API_SECRET=your_gmo_api_secret
+
+# Allowed trading symbols (comma separated)
+ALLOWED_SYMBOLS=BTC_JPY
+
+# Entry policy. "ignore" means new ENTRY signals are ignored when a position is already open.
+ENTRY_POLICY=ignore
+
+# Maximum allowed skew between webhook timestamp and server time in seconds
+MAX_SKEW_SECONDS=60
+
+# Quantity rounding configuration
+QTY_STEP=0.01
+MIN_QTY=0.01
+
+# Discord webhook URL for notifications
+NOTIFY_DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/xxx/yyy
+
+# Deployment environment label
+ENV=prod

--- a/TradingView-GMOcoin-bot-exec-lane-v1/docker-compose.yml
+++ b/TradingView-GMOcoin-bot-exec-lane-v1/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.9"
+
+services:
+  exec-lane:
+    build:
+      context: ./exec-lane
+    env_file:
+      - ./config/.env
+    ports:
+      - "8080:8080"
+    restart: unless-stopped
+    volumes:
+      - ./exec-lane/runtime.db:/app/runtime.db
+    environment:
+      - PYTHONUNBUFFERED=1
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+# Example of optional uptime monitoring service
+#  kuma:
+#    image: louislam/uptime-kuma:1
+#    container_name: uptime-kuma
+#    volumes:
+#      - ./kuma-data:/app/data
+#    ports:
+#      - "3001:3001"
+#    restart: unless-stopped

--- a/TradingView-GMOcoin-bot-exec-lane-v1/exec-lane/Dockerfile
+++ b/TradingView-GMOcoin-bot-exec-lane-v1/exec-lane/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.11-slim
+
+ENV POETRY_VIRTUALENVS_CREATE=false \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /app
+
+RUN useradd -ms /bin/bash appuser
+USER appuser
+
+EXPOSE 8080
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/TradingView-GMOcoin-bot-exec-lane-v1/exec-lane/app.py
+++ b/TradingView-GMOcoin-bot-exec-lane-v1/exec-lane/app.py
@@ -1,0 +1,599 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import platform
+import time
+from collections import defaultdict
+from datetime import datetime, timezone
+from decimal import Decimal, ROUND_DOWN, getcontext
+from typing import Any, Dict, List, Optional
+
+import orjson
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+from dotenv import dotenv_values
+from pydantic import BaseModel, Field, ValidationError, root_validator
+
+import httpx
+
+import gmo
+import notify
+import storage
+
+if platform.system() == "Linux":  # pragma: no cover - uvloop optional
+    try:
+        import uvloop
+
+        uvloop.install()
+    except Exception:  # pragma: no cover - fallback when uvloop missing
+        pass
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger("exec-lane")
+
+getcontext().prec = 18
+
+
+class Settings(BaseModel):
+    webhook_token: str = Field(..., alias="WEBHOOK_TOKEN")
+    api_key: str = Field(..., alias="GMO_API_KEY")
+    api_secret: str = Field(..., alias="GMO_API_SECRET")
+    allowed_symbols: List[str] = Field(..., alias="ALLOWED_SYMBOLS")
+    entry_policy: str = Field("ignore", alias="ENTRY_POLICY")
+    max_skew_seconds: int = Field(60, alias="MAX_SKEW_SECONDS")
+    qty_step: Decimal = Field(Decimal("0.01"), alias="QTY_STEP")
+    min_qty: Decimal = Field(Decimal("0.01"), alias="MIN_QTY")
+    notify_discord_webhook_url: Optional[str] = Field(None, alias="NOTIFY_DISCORD_WEBHOOK_URL")
+    env: str = Field("prod", alias="ENV")
+    symbol: str = "BTC_JPY"
+    idempotency_ttl: int = 600
+
+    @root_validator(pre=True)
+    def split_symbols(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        symbols = values.get("ALLOWED_SYMBOLS")
+        if isinstance(symbols, str):
+            values["ALLOWED_SYMBOLS"] = [s.strip() for s in symbols.split(",") if s.strip()]
+        return values
+
+
+class BaseWebhook(BaseModel):
+    token: str
+    event_id: str
+    ts: datetime
+    mode: str
+    symbol: str
+
+    @root_validator
+    def ensure_mode(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        mode = values.get("mode")
+        if mode not in {"ENTRY", "CLOSE"}:
+            raise ValueError("mode must be ENTRY or CLOSE")
+        return values
+
+
+class EntryWebhook(BaseWebhook):
+    side: str
+    size: Decimal
+
+    @root_validator
+    def validate_entry(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        side = values.get("side")
+        if side not in {"BUY", "SELL"}:
+            raise ValueError("side must be BUY or SELL")
+        size = values.get("size")
+        if size is None:
+            raise ValueError("size is required for ENTRY")
+        return values
+
+
+class CloseWebhook(BaseWebhook):
+    pass
+
+
+def load_settings() -> Settings:
+    config_path = os.path.join(os.path.dirname(__file__), "..", "config", ".env")
+    env_values = {}
+    if os.path.exists(config_path):
+        env_values.update({k: v for k, v in dotenv_values(config_path).items() if v is not None})
+    env_values.update({k: v for k, v in os.environ.items() if v is not None})
+    try:
+        settings = Settings.parse_obj(env_values)
+    except ValidationError as exc:
+        raise RuntimeError(f"Invalid configuration: {exc}") from exc
+    return settings
+
+
+settings = load_settings()
+
+app = FastAPI(title="TradingView GMO Coin Exec Lane", version="1.0.0")
+
+runtime_state: Dict[str, Any] = {
+    "position_qty": Decimal("0"),
+    "position_side": "FLAT",
+    "last_event_id": None,
+    "last_event_ts": None,
+    "events_processed": 0,
+    "retry_stats": {},
+    "ws_connected": False,
+    "ws_reconnects": 0,
+    "retries_total": 0,
+}
+
+state_lock = asyncio.Lock()
+trade_lock = asyncio.Lock()
+execution_lock = asyncio.Lock()
+execution_events: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+execution_waiters: Dict[str, asyncio.Event] = {}
+
+
+def json_log(level: str, **payload: Any) -> None:
+    line = orjson.dumps(payload).decode()
+    log_level = getattr(logging, level.upper(), logging.INFO)
+    logger.log(log_level, line)
+
+
+async def wait_for_order_fill(order_id: Optional[str], timeout: float = 10.0) -> List[Dict[str, Any]]:
+    if not order_id:
+        return []
+    async with execution_lock:
+        existing = execution_events.get(order_id)
+        if existing:
+            return execution_events.pop(order_id)
+        event = asyncio.Event()
+        execution_waiters[order_id] = event
+    try:
+        await asyncio.wait_for(execution_waiters[order_id].wait(), timeout)
+    except asyncio.TimeoutError:
+        return []
+    finally:
+        async with execution_lock:
+            execution_waiters.pop(order_id, None)
+    async with execution_lock:
+        return execution_events.pop(order_id, [])
+
+
+async def record_execution_event(message: Dict[str, Any]) -> None:
+    events = message.get("data") or []
+    async with execution_lock:
+        for item in events:
+            order_id = str(item.get("orderId") or item.get("order_id") or "")
+            if not order_id:
+                continue
+            execution_events[order_id].append(item)
+            waiter = execution_waiters.get(order_id)
+            if waiter:
+                waiter.set()
+
+
+async def update_position_state(message: Dict[str, Any]) -> None:
+    summaries = message.get("data") or []
+    qty = Decimal("0")
+    side = "FLAT"
+    for summary in summaries:
+        if summary.get("symbol") != settings.symbol:
+            continue
+        size = summary.get("size") or summary.get("holdingQuantity") or 0
+        side_value = summary.get("side") or summary.get("positionSide") or "FLAT"
+        qty = Decimal(str(size))
+        side = str(side_value).upper()
+    async with state_lock:
+        runtime_state["position_qty"] = qty
+        runtime_state["position_side"] = side
+    await asyncio.to_thread(storage.set_state, "position_qty", qty)
+    await asyncio.to_thread(storage.set_state, "position_side", side)
+
+
+def compute_avg_price(executions: List[Dict[str, Any]]) -> Optional[float]:
+    if not executions:
+        return None
+    total = Decimal("0")
+    qty = Decimal("0")
+    for item in executions:
+        price = item.get("price") or item.get("executionPrice")
+        size = item.get("size") or item.get("executionSize")
+        if price is None or size is None:
+            continue
+        price_dec = Decimal(str(price))
+        size_dec = Decimal(str(size))
+        total += price_dec * size_dec
+        qty += size_dec
+    if qty <= 0:
+        return None
+    return float((total / qty))
+
+
+def quantize_size(value: Decimal) -> Decimal:
+    step = settings.qty_step
+    if step <= 0:
+        return value
+    scaled = (value / step).to_integral_value(rounding=ROUND_DOWN)
+    return scaled * step
+
+
+async def ensure_symbol_allowed(symbol: str) -> None:
+    if symbol not in settings.allowed_symbols:
+        raise HTTPException(status_code=400, detail="symbol not allowed")
+
+
+async def check_auth(payload: BaseWebhook) -> None:
+    if payload.token != settings.webhook_token:
+        raise HTTPException(status_code=401, detail="invalid token")
+
+
+async def check_freshness(payload: BaseWebhook) -> None:
+    ts = payload.ts
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    now = datetime.now(timezone.utc)
+    skew = abs((now - ts).total_seconds())
+    if skew > settings.max_skew_seconds:
+        raise HTTPException(status_code=400, detail="timestamp skew too large")
+
+
+async def ensure_idempotent(event_id: str) -> None:
+    recent = await asyncio.to_thread(storage.exists_recent, event_id, settings.idempotency_ttl)
+    if recent:
+        raise HTTPException(status_code=200, detail="duplicate event")
+    inserted = await asyncio.to_thread(storage.put_event, event_id)
+    if not inserted:
+        raise HTTPException(status_code=200, detail="duplicate event")
+    await asyncio.to_thread(storage.prune_old_events, settings.idempotency_ttl)
+
+
+async def process_entry(payload: EntryWebhook) -> JSONResponse:
+    await ensure_symbol_allowed(payload.symbol)
+    start = time.monotonic()
+    async with trade_lock:
+        async with state_lock:
+            current_qty = runtime_state.get("position_qty", Decimal("0"))
+        if current_qty > 0 and settings.entry_policy == "ignore":
+            json_log(
+                "info",
+                event_id=payload.event_id,
+                mode="ENTRY",
+                symbol=payload.symbol,
+                size=float(payload.size),
+                result="ignored",
+                latency_ms=0,
+                reason="position not flat",
+            )
+            return JSONResponse({"status": "ignored", "reason": "position exists"})
+
+        size = quantize_size(Decimal(str(payload.size)))
+        if size < settings.min_qty:
+            raise HTTPException(status_code=400, detail="size below minimum")
+
+        try:
+            order_data, rest_result = await gmo.market_entry(
+                app.state.rest_client,
+                settings.api_key,
+                settings.api_secret,
+                payload.symbol,
+                payload.side,
+                size,
+                logger=logger,
+            )
+        except gmo.GMORetryableError as err:
+            await notify.notify_error(
+                settings.notify_discord_webhook_url,
+                event_id=payload.event_id,
+                mode="ENTRY",
+                symbol=payload.symbol,
+                attempt=f"{len(getattr(err, 'attempts', []))}/3",
+                code=getattr(err, "code", None),
+                msg=str(err),
+                http_client=app.state.http_client,
+            )
+            json_log(
+                "error",
+                event_id=payload.event_id,
+                mode="ENTRY",
+                symbol=payload.symbol,
+                size=float(size),
+                result="failure",
+                latency_ms=(time.monotonic() - start) * 1000,
+                err=str(err),
+            )
+            raise HTTPException(status_code=502, detail="entry failed") from err
+        except gmo.GMOAPIError as err:
+            await notify.notify_error(
+                settings.notify_discord_webhook_url,
+                event_id=payload.event_id,
+                mode="ENTRY",
+                symbol=payload.symbol,
+                attempt="1/1",
+                code=err.code,
+                msg=str(err),
+                http_client=app.state.http_client,
+            )
+            json_log(
+                "error",
+                event_id=payload.event_id,
+                mode="ENTRY",
+                symbol=payload.symbol,
+                size=float(size),
+                result="failure",
+                latency_ms=(time.monotonic() - start) * 1000,
+                err=str(err),
+            )
+            raise HTTPException(status_code=400, detail="entry rejected") from err
+
+        order_info = order_data.get("data") or order_data
+        order_id = order_info.get("orderId") or order_info.get("order_id")
+        executions = await wait_for_order_fill(order_id)
+        avg_price = compute_avg_price(executions)
+
+        total_latency = (time.monotonic() - start) * 1000
+        await notify.notify_entry_success(
+            settings.notify_discord_webhook_url,
+            event_id=payload.event_id,
+            symbol=payload.symbol,
+            side=payload.side,
+            size=float(size),
+            avg_px=avg_price,
+            latency_ms=total_latency,
+            http_client=app.state.http_client,
+        )
+
+        async with state_lock:
+            runtime_state["last_event_id"] = payload.event_id
+            runtime_state["last_event_ts"] = payload.ts.isoformat()
+            runtime_state["events_processed"] += 1
+            runtime_state["retry_stats"]["entry"] = rest_result.attempts
+            runtime_state["retries_total"] += len(rest_result.attempts)
+
+        json_log(
+            "info",
+            event_id=payload.event_id,
+            mode="ENTRY",
+            symbol=payload.symbol,
+            size=float(size),
+            result="success",
+            latency_ms=total_latency,
+        )
+        await asyncio.to_thread(storage.set_state, "last_event_id", payload.event_id)
+        await asyncio.to_thread(storage.set_state, "last_event_ts", payload.ts.isoformat())
+        return JSONResponse({"status": "ok", "order_id": order_id})
+
+
+async def process_close(payload: CloseWebhook) -> JSONResponse:
+    await ensure_symbol_allowed(payload.symbol)
+    start = time.monotonic()
+    async with trade_lock:
+        positions = await gmo.get_positions(
+            app.state.rest_client,
+            settings.api_key,
+            settings.api_secret,
+            payload.symbol,
+            logger=logger,
+        )
+        if not positions:
+            await notify.notify_flat(
+                settings.notify_discord_webhook_url,
+                event_id=payload.event_id,
+                symbol=payload.symbol,
+                http_client=app.state.http_client,
+            )
+            json_log(
+                "info",
+                event_id=payload.event_id,
+                mode="CLOSE",
+                symbol=payload.symbol,
+                size=0,
+                result="already_flat",
+                latency_ms=0,
+            )
+            return JSONResponse({"status": "ok", "detail": "already flat"})
+
+        total_size = sum(Decimal(pos.get("size", "0")) for pos in positions)
+
+        try:
+            close_data, rest_result = await gmo.market_close_all(
+                app.state.rest_client,
+                settings.api_key,
+                settings.api_secret,
+                payload.symbol,
+                logger=logger,
+            )
+        except gmo.GMORetryableError as err:
+            await notify.notify_error(
+                settings.notify_discord_webhook_url,
+                event_id=payload.event_id,
+                mode="CLOSE",
+                symbol=payload.symbol,
+                attempt=f"{len(getattr(err, 'attempts', []))}/3",
+                code=getattr(err, "code", None),
+                msg=str(err),
+                http_client=app.state.http_client,
+            )
+            json_log(
+                "error",
+                event_id=payload.event_id,
+                mode="CLOSE",
+                symbol=payload.symbol,
+                size=float(total_size),
+                result="failure",
+                latency_ms=(time.monotonic() - start) * 1000,
+                err=str(err),
+            )
+            raise HTTPException(status_code=502, detail="close failed") from err
+        except gmo.GMOAPIError as err:
+            await notify.notify_error(
+                settings.notify_discord_webhook_url,
+                event_id=payload.event_id,
+                mode="CLOSE",
+                symbol=payload.symbol,
+                attempt="1/1",
+                code=err.code,
+                msg=str(err),
+                http_client=app.state.http_client,
+            )
+            json_log(
+                "error",
+                event_id=payload.event_id,
+                mode="CLOSE",
+                symbol=payload.symbol,
+                size=float(total_size),
+                result="failure",
+                latency_ms=(time.monotonic() - start) * 1000,
+                err=str(err),
+            )
+            raise HTTPException(status_code=400, detail="close rejected") from err
+
+        order_info = close_data.get("data") or close_data
+        order_id = order_info.get("orderId") or order_info.get("order_id")
+        executions = await wait_for_order_fill(order_id)
+        avg_price = compute_avg_price(executions)
+
+        total_latency = (time.monotonic() - start) * 1000
+        await notify.notify_close_success(
+            settings.notify_discord_webhook_url,
+            event_id=payload.event_id,
+            symbol=payload.symbol,
+            closed_qty=float(total_size),
+            avg_px=avg_price,
+            realized_pnl=None,
+            latency_ms=total_latency,
+            http_client=app.state.http_client,
+        )
+
+        async with state_lock:
+            runtime_state["last_event_id"] = payload.event_id
+            runtime_state["last_event_ts"] = payload.ts.isoformat()
+            runtime_state["events_processed"] += 1
+            runtime_state["retry_stats"]["close"] = rest_result.attempts
+            runtime_state["retries_total"] += len(rest_result.attempts)
+
+        json_log(
+            "info",
+            event_id=payload.event_id,
+            mode="CLOSE",
+            symbol=payload.symbol,
+            size=float(total_size),
+            result="success",
+            latency_ms=total_latency,
+        )
+        await asyncio.to_thread(storage.set_state, "last_event_id", payload.event_id)
+        await asyncio.to_thread(storage.set_state, "last_event_ts", payload.ts.isoformat())
+        return JSONResponse({"status": "ok", "order_id": order_id})
+
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    storage.init_db()
+    app.state.rest_client = gmo.create_rest_client()
+    app.state.http_client = httpx.AsyncClient(timeout=10.0)
+    positions = await gmo.get_positions(
+        app.state.rest_client,
+        settings.api_key,
+        settings.api_secret,
+        settings.symbol,
+        logger=logger,
+    )
+    total_qty = sum(Decimal(pos.get("size", "0")) for pos in positions)
+    side = "FLAT"
+    if positions:
+        side = positions[0].get("side", "FLAT").upper()
+    async with state_lock:
+        runtime_state["position_qty"] = total_qty
+        runtime_state["position_side"] = side
+    await asyncio.to_thread(storage.set_state, "position_qty", total_qty)
+    await asyncio.to_thread(storage.set_state, "position_side", side)
+
+    async def position_callback(message: Dict[str, Any]) -> None:
+        await update_position_state(message)
+
+    async def execution_callback(message: Dict[str, Any]) -> None:
+        await record_execution_event(message)
+
+    def status_callback(is_connected: bool) -> None:
+        async def update_state() -> None:
+            async with state_lock:
+                if not is_connected:
+                    runtime_state["ws_reconnects"] += 1
+                runtime_state["ws_connected"] = is_connected
+        asyncio.create_task(update_state())
+
+    app.state.ws_task = asyncio.create_task(
+        gmo.websocket_loop(
+            settings.api_key,
+            settings.api_secret,
+            settings.symbol,
+            position_callback,
+            execution_callback,
+            status_callback,
+            logger=logger,
+        )
+    )
+
+
+@app.on_event("shutdown")
+async def on_shutdown() -> None:
+    if hasattr(app.state, "ws_task"):
+        app.state.ws_task.cancel()
+        with contextlib.suppress(Exception):
+            await app.state.ws_task
+    if hasattr(app.state, "rest_client"):
+        await app.state.rest_client.aclose()
+    if hasattr(app.state, "http_client"):
+        await app.state.http_client.aclose()
+
+
+@app.post("/webhook")
+async def webhook_endpoint(request: Request) -> JSONResponse:
+    try:
+        data = await request.json()
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="invalid json") from exc
+
+    try:
+        base = BaseWebhook.parse_obj(data)
+        payload: BaseWebhook
+        if base.mode == "ENTRY":
+            payload = EntryWebhook.parse_obj(data)
+        else:
+            payload = CloseWebhook.parse_obj(data)
+    except ValidationError as exc:
+        raise HTTPException(status_code=422, detail=exc.errors()) from exc
+
+    await check_auth(payload)
+    await check_freshness(payload)
+    try:
+        await ensure_idempotent(payload.event_id)
+    except HTTPException as exc:
+        if exc.status_code == 200:
+            return JSONResponse({"status": "duplicate"})
+        raise
+
+    if payload.mode == "ENTRY":
+        return await process_entry(payload)  # type: ignore[arg-type]
+    return await process_close(payload)  # type: ignore[arg-type]
+
+
+@app.get("/healthz")
+async def healthz() -> JSONResponse:
+    try:
+        await asyncio.to_thread(storage.prune_old_events, settings.idempotency_ttl)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail="db error") from exc
+    return JSONResponse({"status": "ok"})
+
+
+@app.get("/status")
+async def status_endpoint() -> JSONResponse:
+    async with state_lock:
+        snapshot = {
+            "position_qty": float(runtime_state.get("position_qty", Decimal("0"))),
+            "position_side": runtime_state.get("position_side"),
+            "last_event_id": runtime_state.get("last_event_id"),
+            "last_event_ts": runtime_state.get("last_event_ts"),
+            "events_processed": runtime_state.get("events_processed"),
+            "retry_stats": runtime_state.get("retry_stats"),
+            "ws_connected": runtime_state.get("ws_connected"),
+            "ws_reconnects": runtime_state.get("ws_reconnects"),
+            "retries_total": runtime_state.get("retries_total"),
+        }
+    return JSONResponse(snapshot)

--- a/TradingView-GMOcoin-bot-exec-lane-v1/exec-lane/gmo.py
+++ b/TradingView-GMOcoin-bot-exec-lane-v1/exec-lane/gmo.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import logging
+import time
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence, Tuple
+
+import httpx
+import pybotters
+
+REST_BASE_URL = "https://api.coin.z.com"
+PRIVATE_PREFIX = "/private/v1"
+WS_URL = "wss://api.coin.z.com/private/v1/ws"
+
+JsonDict = Dict[str, Any]
+
+
+@dataclass
+class RestResult:
+    data: JsonDict
+    attempts: List[JsonDict]
+    latency_ms: float
+
+
+class GMOAPIError(Exception):
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: Optional[str] = None,
+        status: Optional[int] = None,
+        attempts: Optional[List[JsonDict]] = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.status = status
+        self.attempts = attempts or []
+
+
+class GMORetryableError(GMOAPIError):
+    pass
+
+
+def create_rest_client(timeout: float = 10.0) -> httpx.AsyncClient:
+    return httpx.AsyncClient(base_url=REST_BASE_URL, timeout=timeout)
+
+
+async def rest_request(
+    client: httpx.AsyncClient,
+    method: str,
+    path: str,
+    api_key: str,
+    api_secret: str,
+    *,
+    params: Optional[Dict[str, Any]] = None,
+    json_body: Optional[Dict[str, Any]] = None,
+    retry_backoff: Sequence[float] = (0.5, 1.0, 2.0),
+    logger: Optional[logging.Logger] = None,
+) -> RestResult:
+    body_str = json.dumps(json_body, separators=(",", ":")) if json_body is not None else ""
+    attempts: List[JsonDict] = []
+    start = time.monotonic()
+    for attempt, backoff in enumerate(retry_backoff, start=1):
+        timestamp = str(int(time.time() * 1000))
+        sign_target = f"{timestamp}{method}{path}{body_str}"
+        signature = hmac.new(api_secret.encode(), sign_target.encode(), hashlib.sha256).hexdigest()
+        headers = {
+            "X-API-KEY": api_key,
+            "X-SIGNATURE": signature,
+            "X-TIMESTAMP": timestamp,
+            "Content-Type": "application/json",
+        }
+        try:
+            response = await client.request(
+                method,
+                path,
+                params=params,
+                content=body_str if json_body is not None else None,
+                headers=headers,
+            )
+        except httpx.RequestError as exc:  # network/timeout
+            attempts.append({"attempt": attempt, "error": str(exc), "type": "exception"})
+            if attempt == len(retry_backoff):
+                raise GMORetryableError("Request failed after retries", attempts=attempts) from exc
+            if logger:
+                logger.warning("REST request exception", extra={"attempt": attempt, "err": str(exc)})
+            await asyncio.sleep(backoff)
+            continue
+
+        status = response.status_code
+        content_type = response.headers.get("Content-Type", "")
+        data: JsonDict
+        if "application/json" in content_type:
+            data = response.json()
+        else:
+            data = {"status": status, "body": response.text}
+
+        if status in {429} or status >= 500:
+            attempts.append(
+                {
+                    "attempt": attempt,
+                    "status": status,
+                    "type": "http_error",
+                    "body": data,
+                }
+            )
+            if attempt == len(retry_backoff):
+                raise GMORetryableError(
+                    f"HTTP {status} after retries", status=status, attempts=attempts
+                )
+            if logger:
+                logger.warning("REST retry due to status", extra={"attempt": attempt, "status": status})
+            await asyncio.sleep(backoff)
+            continue
+
+        if isinstance(data, dict) and data.get("status") not in (0, "0", None):
+            code = None
+            message = "Unknown error"
+            messages = data.get("messages") or []
+            if messages:
+                first = messages[0]
+                code = first.get("message_code")
+                message = first.get("message_string", message)
+            raise GMOAPIError(message, code=code, status=status, attempts=attempts)
+
+        latency_ms = (time.monotonic() - start) * 1000.0
+        return RestResult(data=data, attempts=attempts, latency_ms=latency_ms)
+
+    raise GMORetryableError("Unhandled retry termination", attempts=attempts)
+
+
+async def get_positions(
+    client: httpx.AsyncClient,
+    api_key: str,
+    api_secret: str,
+    symbol: str,
+    *,
+    logger: Optional[logging.Logger] = None,
+) -> List[JsonDict]:
+    result = await rest_request(
+        client,
+        "GET",
+        f"{PRIVATE_PREFIX}/openPositions",
+        api_key,
+        api_secret,
+        params={"symbol": symbol},
+        logger=logger,
+    )
+    data = result.data.get("data") or []
+    return data
+
+
+async def market_entry(
+    client: httpx.AsyncClient,
+    api_key: str,
+    api_secret: str,
+    symbol: str,
+    side: str,
+    size: Decimal,
+    *,
+    logger: Optional[logging.Logger] = None,
+) -> Tuple[JsonDict, RestResult]:
+    payload = {
+        "symbol": symbol,
+        "side": side,
+        "executionType": "MARKET",
+        "size": format(size, "f"),
+        "timeInForce": "FAS",
+    }
+    result = await rest_request(
+        client,
+        "POST",
+        f"{PRIVATE_PREFIX}/order",
+        api_key,
+        api_secret,
+        json_body=payload,
+        logger=logger,
+    )
+    return result.data, result
+
+
+async def market_close_all(
+    client: httpx.AsyncClient,
+    api_key: str,
+    api_secret: str,
+    symbol: str,
+    *,
+    logger: Optional[logging.Logger] = None,
+) -> Tuple[JsonDict, RestResult]:
+    positions = await get_positions(client, api_key, api_secret, symbol, logger=logger)
+    if not positions:
+        result = RestResult(data={"data": {"closed": []}}, attempts=[], latency_ms=0.0)
+        return result.data, result
+
+    settle_list: List[Dict[str, Any]] = []
+    total_size = Decimal("0")
+    close_side = None
+    for pos in positions:
+        pos_size = Decimal(pos.get("size", "0"))
+        if pos_size <= 0:
+            continue
+        total_size += pos_size
+        position_id = pos.get("positionId") or pos.get("position_id")
+        settle_list.append({"positionId": position_id, "size": format(pos_size, "f")})
+        side = pos.get("side")
+        if side:
+            close_side = "SELL" if side.upper() == "BUY" else "BUY"
+    if total_size <= 0 or not settle_list:
+        result = RestResult(data={"data": {"closed": []}}, attempts=[], latency_ms=0.0)
+        return result.data, result
+
+    payload = {
+        "symbol": symbol,
+        "side": close_side or "SELL",
+        "executionType": "MARKET",
+        "size": format(total_size, "f"),
+        "settlePosition": settle_list,
+        "timeInForce": "FAS",
+    }
+
+    try:
+        result = await rest_request(
+            client,
+            "POST",
+            f"{PRIVATE_PREFIX}/closeOrder",
+            api_key,
+            api_secret,
+            json_body=payload,
+            logger=logger,
+        )
+    except GMOAPIError as err:
+        if err.code == "ERR-200":
+            # settle quantity exceeds. try reducing sequentially
+            trimmed_list: List[Dict[str, Any]] = []
+            total = Decimal("0")
+            for pos in settle_list:
+                sz = Decimal(pos["size"])
+                if total + sz > total_size:
+                    sz = total_size - total
+                total += sz
+                if sz <= 0:
+                    continue
+                trimmed_list.append({"positionId": pos["positionId"], "size": format(sz, "f")})
+            payload["settlePosition"] = trimmed_list
+            payload["size"] = format(total, "f")
+            result = await rest_request(
+                client,
+                "POST",
+                f"{PRIVATE_PREFIX}/closeOrder",
+                api_key,
+                api_secret,
+                json_body=payload,
+                logger=logger,
+            )
+        else:
+            raise
+
+    return result.data, result
+
+
+async def websocket_loop(
+    api_key: str,
+    api_secret: str,
+    symbol: str,
+    position_cb: Callable[[JsonDict], Awaitable[None]],
+    execution_cb: Callable[[JsonDict], Awaitable[None]],
+    status_cb: Callable[[bool], None],
+    *,
+    logger: Optional[logging.Logger] = None,
+) -> None:
+    backoff = 1.0
+    while True:
+        try:
+            async with pybotters.Client(apis={"gmo": (api_key, api_secret)}) as client:
+                async with client.ws_connect(WS_URL) as ws:
+                    status_cb(True)
+                    await ws.send_json(
+                        {
+                            "command": "subscribe",
+                            "channel": "positionSummaryEvents",
+                            "symbol": symbol,
+                        }
+                    )
+                    await ws.send_json(
+                        {
+                            "command": "subscribe",
+                            "channel": "executionEvents",
+                            "symbol": symbol,
+                        }
+                    )
+                    backoff = 1.0
+                    async for msg in ws:
+                        data = msg.json()
+                        channel = data.get("channel")
+                        if channel == "positionSummaryEvents":
+                            await position_cb(data)
+                        elif channel == "executionEvents":
+                            await execution_cb(data)
+        except Exception as exc:  # pragma: no cover - connection errors
+            if logger:
+                logger.error("WS loop error", extra={"err": str(exc)})
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, 30.0)
+            continue
+        finally:
+            status_cb(False)
+

--- a/TradingView-GMOcoin-bot-exec-lane-v1/exec-lane/notify.py
+++ b/TradingView-GMOcoin-bot-exec-lane-v1/exec-lane/notify.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+import httpx
+
+logger = logging.getLogger("notify")
+
+
+async def send_discord_message(
+    webhook_url: Optional[str],
+    level: str,
+    message: str,
+    *,
+    http_client: Optional[httpx.AsyncClient] = None,
+) -> None:
+    if not webhook_url:
+        return
+
+    payload = {"content": f"[{level}] {message}"}
+
+    owned_client = False
+    if http_client is None:
+        http_client = httpx.AsyncClient(timeout=5.0)
+        owned_client = True
+
+    try:
+        response = await http_client.post(webhook_url, json=payload)
+        if response.status_code >= 400:
+            logger.error(
+                "Discord webhook failed",
+                extra={"status": response.status_code, "body": response.text},
+            )
+    except Exception as exc:  # pragma: no cover - network errors
+        logger.error("Discord webhook exception", extra={"err": str(exc)})
+    finally:
+        if owned_client:
+            await http_client.aclose()
+
+
+async def notify_entry_success(
+    webhook_url: Optional[str],
+    *,
+    event_id: str,
+    symbol: str,
+    side: str,
+    size: float,
+    avg_px: Optional[float],
+    latency_ms: float,
+    http_client: Optional[httpx.AsyncClient] = None,
+) -> None:
+    avg_part = f" | avg_px={avg_px:.0f}" if avg_px is not None else ""
+    message = (
+        f"event_id={event_id} | symbol={symbol} | side={side} | size={size:.4f}"\
+        f"{avg_part} | latency={int(latency_ms)}ms"
+    )
+    await send_discord_message(webhook_url, "INFO", message, http_client=http_client)
+
+
+async def notify_close_success(
+    webhook_url: Optional[str],
+    *,
+    event_id: str,
+    symbol: str,
+    closed_qty: float,
+    avg_px: Optional[float],
+    realized_pnl: Optional[float],
+    latency_ms: float,
+    http_client: Optional[httpx.AsyncClient] = None,
+) -> None:
+    avg_part = f" | avg_px={avg_px:.0f}" if avg_px is not None else ""
+    pnl_part = (
+        f" | realized_pnl={'+' if (realized_pnl or 0) >= 0 else ''}{realized_pnl:.0f} JPY"
+        if realized_pnl is not None
+        else ""
+    )
+    message = (
+        f"event_id={event_id} | symbol={symbol} | closed_qty={closed_qty:.4f}"\
+        f"{avg_part}{pnl_part} | latency={int(latency_ms)}ms"
+    )
+    await send_discord_message(webhook_url, "INFO", message, http_client=http_client)
+
+
+async def notify_error(
+    webhook_url: Optional[str],
+    *,
+    event_id: str,
+    mode: str,
+    symbol: str,
+    attempt: str,
+    code: Optional[str],
+    msg: str,
+    http_client: Optional[httpx.AsyncClient] = None,
+) -> None:
+    code_part = f" | code={code}" if code else ""
+    message = (
+        f"event_id={event_id} | mode={mode} | symbol={symbol} | attempt={attempt}"\
+        f"{code_part} | msg={msg} | next=stop"
+    )
+    await send_discord_message(webhook_url, "ERROR", message, http_client=http_client)
+
+
+async def notify_flat(
+    webhook_url: Optional[str],
+    *,
+    event_id: str,
+    symbol: str,
+    http_client: Optional[httpx.AsyncClient] = None,
+) -> None:
+    message = f"event_id={event_id} | symbol={symbol} | status=already flat"
+    await send_discord_message(webhook_url, "INFO", message, http_client=http_client)

--- a/TradingView-GMOcoin-bot-exec-lane-v1/exec-lane/requirements.txt
+++ b/TradingView-GMOcoin-bot-exec-lane-v1/exec-lane/requirements.txt
@@ -1,0 +1,8 @@
+fastapi
+uvicorn[standard]
+pybotters
+httpx
+pydantic
+python-dotenv
+orjson
+uvloop; platform_system == "Linux"

--- a/TradingView-GMOcoin-bot-exec-lane-v1/exec-lane/storage.py
+++ b/TradingView-GMOcoin-bot-exec-lane-v1/exec-lane/storage.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import sqlite3
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+DB_PATH = Path(__file__).resolve().parent / "runtime.db"
+
+
+def init_db() -> None:
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with _connect() as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS idempotency (
+                event_id TEXT PRIMARY KEY,
+                created_at INTEGER NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS state (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL,
+                updated_at INTEGER NOT NULL
+            )
+            """
+        )
+        conn.commit()
+
+
+def prune_old_events(ttl_sec: int = 600) -> None:
+    threshold = int(time.time()) - ttl_sec
+    with _connect() as conn:
+        conn.execute("DELETE FROM idempotency WHERE created_at < ?", (threshold,))
+        conn.commit()
+
+
+def put_event(event_id: str) -> bool:
+    now = int(time.time())
+    with _connect() as conn:
+        try:
+            conn.execute(
+                "INSERT INTO idempotency (event_id, created_at) VALUES (?, ?)",
+                (event_id, now),
+            )
+            conn.commit()
+            return True
+        except sqlite3.IntegrityError:
+            return False
+
+
+def exists_recent(event_id: str, ttl_sec: int = 600) -> bool:
+    now = int(time.time())
+    with _connect() as conn:
+        row = conn.execute(
+            "SELECT created_at FROM idempotency WHERE event_id = ?", (event_id,)
+        ).fetchone()
+    if row is None:
+        return False
+    created_at = int(row[0])
+    if now - created_at <= ttl_sec:
+        return True
+    delete_event(event_id)
+    return False
+
+
+def delete_event(event_id: str) -> None:
+    with _connect() as conn:
+        conn.execute("DELETE FROM idempotency WHERE event_id = ?", (event_id,))
+        conn.commit()
+
+
+def set_state(key: str, value: Any) -> None:
+    now = int(time.time())
+    with _connect() as conn:
+        conn.execute(
+            "INSERT INTO state (key, value, updated_at) VALUES (?, ?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
+            (key, str(value), now),
+        )
+        conn.commit()
+
+
+def get_state(key: str, default: Optional[Any] = None) -> Optional[str]:
+    with _connect() as conn:
+        row = conn.execute("SELECT value FROM state WHERE key = ?", (key,)).fetchone()
+    if row is None:
+        return default
+    return row[0]
+
+
+def export_state() -> Dict[str, Any]:
+    with _connect() as conn:
+        rows = conn.execute("SELECT key, value, updated_at FROM state").fetchall()
+    return {row[0]: row[1] for row in rows}
+
+
+@contextmanager
+def _connect():
+    conn = sqlite3.connect(DB_PATH)
+    try:
+        yield conn
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary
- scaffold TradingView-driven GMO Coin execution lane with FastAPI application, Docker setup, and configuration samples
- implement REST/WS wrappers, SQLite idempotency storage, and Discord notifier for order lifecycle events
- document deployment, TradingView alert payloads, smoke tests, and operational guidance

## Testing
- `python -m py_compile TradingView-GMOcoin-bot-exec-lane-v1/exec-lane/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68d32501f8648322a5662f0fc67dbe4c