### PR TITLE
Add BTCJPY entry/close bot deployment stack

### DIFF
--- a/btcjpy-entry-close-bot/README.md
+++ b/btcjpy-entry-close-bot/README.md
@@ -1,0 +1,214 @@
+# BTCJPY ENTRY/CLOSE Bot
+
+TradingView Essential からの Webhook を受信し、pybotters 経由で GMOコイン（レバレッジ）に対して BTC_JPY の成行 ENTRY / CLOSE を実行するためのコンテナ一式です。Discord Webhook への通知、冪等チェック、鮮度検査、Cloudflared トンネル公開を前提としています。
+
+## ディレクトリ構成
+
+```
+btcjpy-entry-close-bot/
+├─ docker-compose.yml
+├─ README.md
+├─ config/
+│  ├─ .env.example
+│  └─ gunicorn_conf.py
+├─ exec-lane/
+│  ├─ Dockerfile
+│  ├─ app.py
+│  ├─ gmo.py
+│  ├─ notify.py
+│  ├─ requirements.txt
+│  ├─ runtime.py
+│  └─ ws.py
+└─ logs/
+   └─ .gitkeep
+```
+
+`logs/` は SQLite と構造化ログの格納ディレクトリです。コンテナ実行ユーザ（非 root）が書き込めるように docker-compose 側でボリュームマウントします。
+
+## 事前準備
+
+### 1. リポジトリ一式の転送
+
+1. ローカルで ZIP 化
+   - **Windows (PowerShell)**
+     ```powershell
+     cd <プロジェクト配置ディレクトリ>
+     Compress-Archive -Path btcjpy-entry-close-bot -DestinationPath btcjpy-entry-close-bot.zip -Force
+     ```
+   - **Linux / macOS**
+     ```bash
+     cd <プロジェクト配置ディレクトリ>
+     zip -r btcjpy-entry-close-bot.zip btcjpy-entry-close-bot
+     ```
+2. ConoHa VPS へ転送
+   - **Windows**: `pscp` (PuTTY) などを利用
+     ```powershell
+     pscp .\btcjpy-entry-close-bot.zip user@<your_vps_ip>:/home/user/
+     ```
+   - **Linux / macOS**
+     ```bash
+     scp btcjpy-entry-close-bot.zip user@<your_vps_ip>:/home/user/
+     ```
+3. VPS 上で展開
+   ```bash
+   ssh user@<your_vps_ip>
+   cd /home/user
+   unzip btcjpy-entry-close-bot.zip
+   ```
+4. 配置確認
+   ```bash
+   find btcjpy-entry-close-bot -maxdepth 2 -type f
+   ```
+
+### 2. `.env` の作成
+
+`config/.env.example` をベースに実運用用の `config/.env` を作成し、改行コードを LF へ統一します。`dos2unix` を推奨します。
+
+```bash
+cd /home/user/btcjpy-entry-close-bot
+cp config/.env.example config/.env
+nano config/.env  # 値を編集
+sudo apt-get update && sudo apt-get install -y dos2unix
+find config -maxdepth 1 -type f -name '*.env' -exec dos2unix {} +
+```
+
+> **注意**: `.env` にクォート（`"`）やスペースが紛れ込むと API キー長チェックで検知されます。起動時ログに `length` と `repr_len` が記録されるので、期待値（KEY=32, SECRET=64）が一致するか必ず確認してください。
+
+### 3. 必須環境変数
+
+| 変数 | 説明 |
+| ---- | ---- |
+| `WEBHOOK_TOKEN` | TradingView Webhook JSON の `token` と一致させる値 |
+| `GMO_API_KEY` | GMOコイン API KEY（32文字） |
+| `GMO_API_SECRET` | GMOコイン API SECRET（64文字） |
+| `ALLOWED_SYMBOLS` | 取引対象シンボル（カンマ区切り）。初期値は `BTC_JPY` |
+| `ENTRY_POLICY` | `ignore` 固定（建玉中のENTRYは無視） |
+| `MAX_SKEW_SECONDS` | Webhook 時刻の許容ズレ秒数。デフォルト 60 |
+| `QTY_STEP` | 数量丸め単位。GMOコイン BTC レバレッジは 0.01 |
+| `NOTIFY_DISCORD_WEBHOOK_URL` | Discord Webhook URL |
+| `ENV` | 任意の環境識別子（例: `prod`, `stg`） |
+
+### 4. GMOコイン API 準備
+
+- API キーを **現物/レバレッジ共通 API** から取得し、IP 制限を設定してください。
+- `pybotters` が自動で署名ヘッダーを付与するため、追加の署名実装は不要です。
+
+### 5. 時刻同期
+
+Webhook の鮮度チェックは ±60 秒以内が必須です。VPS では `chrony` などで NTP 同期を行ってください。
+
+```bash
+sudo apt-get install -y chrony
+sudo systemctl enable --now chrony
+```
+
+## Docker / Cloudflared セットアップ
+
+1. Docker / Docker Compose v2 を導入（Ubuntu 24.04+）
+   ```bash
+   sudo apt-get update
+   sudo apt-get install -y ca-certificates curl gnupg
+   sudo install -m 0755 -d /etc/apt/keyrings
+   curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+   echo \
+     "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+     $(. /etc/os-release && echo $VERSION_CODENAME) stable" | \
+     sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+   sudo apt-get update
+   sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+   sudo usermod -aG docker $USER
+   newgrp docker
+   ```
+
+2. Cloudflared トンネル
+   - [Cloudflare ドキュメント](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) に従ってトンネルを作成し、`http://127.0.0.1:8080` へルーティングしてください。
+   - 例: `cloudflared tunnel run btcjpy-entry-close-bot` で起動。常駐化には systemd サービスを推奨。
+
+3. Uptime Kuma などの監視ツールで `https://<domain>/healthz` を監視すると稼働監視が容易です。
+
+## ビルド & 起動手順
+
+```bash
+cd /home/user/btcjpy-entry-close-bot
+ls -a  # .env が存在するか確認
+
+docker compose build
+
+docker compose up -d
+```
+
+- 起動後、ログは以下で確認できます。
+  ```bash
+  docker compose logs -f
+  ```
+- `docker compose ps` でコンテナ状態を確認。
+
+## ヘルスチェック
+
+- `GET http://127.0.0.1:8080/healthz` → `{"status":"ok"}`
+- `GET http://127.0.0.1:8080/status` でポジション情報、直近イベント、リトライ統計、WS 接続状態を取得。
+
+## スモークテスト
+
+Cloudflared で公開されたドメイン（例: `https://example.trycloudflare.com`）に対して以下の cURL を実行してください。ローカル検証は `http://127.0.0.1:8080` でも同様です。
+
+### ENTRY
+
+```bash
+curl -iS https://<domain>/webhook \
+ -H "Content-Type: application/json" \
+ --data-binary '{
+  "token":"SECRETxxyyzz",
+  "event_id":"dev-ENTRY-001",
+  "ts":"2025-09-24T00:00:00Z",
+  "mode":"ENTRY",
+  "symbol":"BTC_JPY",
+  "side":"BUY",
+  "size":0.04
+ }'
+```
+
+### CLOSE
+
+```bash
+curl -iS https://<domain>/webhook \
+ -H "Content-Type: application/json" \
+ --data-binary '{
+  "token":"SECRETxxyyzz",
+  "event_id":"dev-CLOSE-001",
+  "ts":"2025-09-24T00:01:00Z",
+  "mode":"CLOSE",
+  "symbol":"BTC_JPY"
+ }'
+```
+
+**期待挙動**
+
+- FastAPI が 200 系レスポンスを返却。
+- GMOコイン API への注文が完了し、約定確認後に Discord へ「ENTRY OK」/「CLOSE OK」が送信。
+- `logs/runtime.log` および標準出力に JSON ログが記録される（`event_id`, `mode`, `result`, `latency_ms` 等）。
+- `.env` のキー長チェックログが `gmo_api_key_length_check` / `gmo_api_secret_length_check` として出力される。
+
+## 運用 Tips
+
+- **dos2unix**: Windows で `.env` を編集した場合は必ず `dos2unix config/.env` を実施してください。CRLF が残ると認証に失敗する恐れがあります。
+- **リトライ**: 429/5xx/timeout は指数バックオフ（0.5 → 1.0 → 2.0 秒）で最大 3 回自動再試行します。最終失敗時は Discord へ ERROR 通知。
+- **時刻ズレ**: `MAX_SKEW_SECONDS` を一時的に 120 に増やすと検証が容易ですが、本番では 60 以下を推奨します。
+- **ログ**: `logs/runtime.db` にイベント履歴が保存され、同一 `event_id` の二重実行を防ぎます。バックアップ時はこのファイルも保存してください。
+- **WS 監視**: 現バージョンでは REST ベースで完結しますが、将来的な WS 拡張用に `ws.py` を配置しています。`/status` の `ws_connected` フラグで接続状態を確認できます（未接続の場合は `false`）。
+- **監視**: Uptime Kuma などで `https://<domain>/healthz` を 1 分間隔で監視し、アラートを設定してください。
+- **更新**: 変更時は `docker compose pull` → `docker compose up -d --build` を実施し、稼働中ログを確認してください。
+
+## トラブルシューティング
+
+| 症状 | 確認ポイント |
+| ---- | ---- |
+| `.env` ロード失敗 | `.env` の改行コード・余計なクォート、`dos2unix` 実施状況 |
+| 429/5xx が頻発 | GMOコイン側のレート制限。API 設定を見直し、ネットワーク経路を確認 |
+| Discord 通知が届かない | Webhook URL の再発行、ファイアウォール設定、`docker compose logs` で `discord_notification_failed` の有無を確認 |
+| Cloudflared 経由アクセス不可 | トンネルのバインド先 (`http://127.0.0.1:8080`) とポート開放を確認。トンネルログを確認 |
+
+## ライセンス
+
+本リポジトリ内のコードは MIT ライセンスに基づき配布されます。
+

--- a/btcjpy-entry-close-bot/config/.env.example
+++ b/btcjpy-entry-close-bot/config/.env.example
@@ -1,0 +1,9 @@
+WEBHOOK_TOKEN=SECRETxxyyzz
+GMO_API_KEY=put_your_key_here_32chars
+GMO_API_SECRET=put_your_secret_here_64chars
+ALLOWED_SYMBOLS=BTC_JPY
+ENTRY_POLICY=ignore
+MAX_SKEW_SECONDS=60
+QTY_STEP=0.01
+NOTIFY_DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/xxxx/xxxx
+ENV=prod

--- a/btcjpy-entry-close-bot/config/gunicorn_conf.py
+++ b/btcjpy-entry-close-bot/config/gunicorn_conf.py
@@ -1,0 +1,11 @@
+import multiprocessing
+import os
+
+bind = "0.0.0.0:8080"
+worker_class = "uvicorn.workers.UvicornWorker"
+workers = int(os.getenv("WEB_CONCURRENCY", multiprocessing.cpu_count()))
+loglevel = os.getenv("LOG_LEVEL", "info")
+accesslog = "-"
+errorlog = "-"
+preload_app = False
+timeout = 60

--- a/btcjpy-entry-close-bot/docker-compose.yml
+++ b/btcjpy-entry-close-bot/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  exec-lane:
+    build:
+      context: ./exec-lane
+    container_name: btcjpy-entry-close-bot
+    env_file:
+      - ./config/.env
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./logs:/app/logs
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8080/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s

--- a/btcjpy-entry-close-bot/exec-lane/Dockerfile
+++ b/btcjpy-entry-close-bot/exec-lane/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+COPY ../config /app/config
+COPY . /app/exec-lane
+
+RUN adduser --disabled-password --gecos "" bot \
+    && mkdir -p /app/logs \
+    && chown -R bot:bot /app
+
+USER bot
+WORKDIR /app/exec-lane
+ENV PYTHONPATH=/app/exec-lane:/app
+
+CMD ["gunicorn", "-c", "/app/config/gunicorn_conf.py", "app:app"]

--- a/btcjpy-entry-close-bot/exec-lane/app.py
+++ b/btcjpy-entry-close-bot/exec-lane/app.py
@@ -1,0 +1,390 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Annotated, Any, Literal, Optional, Union
+
+try:  # uvloop is optional on non-Linux platforms
+    import uvloop  # type: ignore
+except ImportError:  # pragma: no cover
+    uvloop = None  # type: ignore
+else:  # pragma: no cover
+    uvloop.install()
+
+from dotenv import load_dotenv
+from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi.responses import ORJSONResponse
+from loguru import logger
+from pydantic import BaseModel, Field, TypeAdapter, ValidationError, field_validator
+
+from gmo import GMOCoinClient, GMOCoinError
+from notify import DiscordNotifier
+from runtime import EventRecord, RuntimeState
+from ws import GMOWebSocketSupervisor
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+CONFIG_DIR = BASE_DIR / "config"
+LOG_DIR = BASE_DIR / "logs"
+ENV_FILE = CONFIG_DIR / ".env"
+
+load_dotenv(ENV_FILE, override=False)
+
+
+def setup_logging(log_dir: Path) -> None:
+    log_dir.mkdir(parents=True, exist_ok=True)
+    logger.remove()
+    level = os.getenv("LOG_LEVEL", "INFO").upper()
+    logger.add(sys.stdout, level=level, serialize=True, backtrace=False, diagnose=False)
+    logger.add(log_dir / "runtime.log", level=level, serialize=True, rotation="7 days", retention=5)
+
+
+class Settings(BaseModel):
+    webhook_token: str = Field(alias="WEBHOOK_TOKEN")
+    gmo_api_key: str = Field(alias="GMO_API_KEY")
+    gmo_api_secret: str = Field(alias="GMO_API_SECRET")
+    allowed_symbols: set[str] = Field(alias="ALLOWED_SYMBOLS")
+    entry_policy: str = Field(alias="ENTRY_POLICY")
+    max_skew_seconds: int = Field(alias="MAX_SKEW_SECONDS")
+    qty_step: float = Field(alias="QTY_STEP")
+    discord_webhook_url: Optional[str] = Field(default=None, alias="NOTIFY_DISCORD_WEBHOOK_URL")
+    env: str = Field(default="prod", alias="ENV")
+
+    @field_validator("allowed_symbols", mode="before")
+    @classmethod
+    def _split_symbols(cls, value: str | set[str]) -> set[str]:
+        if isinstance(value, set):
+            return value
+        return {symbol.strip() for symbol in value.split(",") if symbol.strip()}
+
+    @field_validator("entry_policy")
+    @classmethod
+    def _validate_policy(cls, value: str) -> str:
+        if value not in {"ignore"}:
+            raise ValueError("unsupported ENTRY_POLICY; expected 'ignore'")
+        return value
+
+
+class WebhookBase(BaseModel):
+    token: str
+    event_id: str
+    ts: datetime
+    mode: Literal["ENTRY", "CLOSE"]
+    symbol: str
+
+    @field_validator("ts")
+    @classmethod
+    def ensure_timezone(cls, value: datetime) -> datetime:
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+
+
+class EntryPayload(WebhookBase):
+    mode: Literal["ENTRY"]
+    side: Literal["BUY", "SELL"]
+    size: float
+
+    @field_validator("size")
+    @classmethod
+    def validate_size(cls, value: float) -> float:
+        if value <= 0:
+            raise ValueError("size must be positive")
+        return value
+
+
+class ClosePayload(WebhookBase):
+    mode: Literal["CLOSE"]
+
+
+WebhookPayloadType = Annotated[Union[EntryPayload, ClosePayload], Field(discriminator="mode")]
+PayloadAdapter = TypeAdapter(WebhookPayloadType)
+
+
+class WebhookResponse(BaseModel):
+    status: str
+    event_id: str
+    mode: str
+    detail: Optional[str] = None
+    latency_ms: Optional[float] = None
+
+
+def create_app() -> FastAPI:
+    setup_logging(LOG_DIR)
+    app = FastAPI(default_response_class=ORJSONResponse)
+
+    settings = Settings.model_validate(os.environ)
+
+    logger.info(
+        "gmo_api_key_length_check",
+        length=len(settings.gmo_api_key),
+        repr_len=len(repr(settings.gmo_api_key)),
+        expected=32,
+    )
+    logger.info(
+        "gmo_api_secret_length_check",
+        length=len(settings.gmo_api_secret),
+        repr_len=len(repr(settings.gmo_api_secret)),
+        expected=64,
+    )
+
+    runtime_state = RuntimeState(
+        db_path=LOG_DIR / "runtime.db",
+        max_skew_seconds=settings.max_skew_seconds,
+        qty_step=settings.qty_step,
+        entry_policy=settings.entry_policy,
+    )
+
+    notifier = DiscordNotifier(settings.discord_webhook_url)
+    gmo_client = GMOCoinClient(settings.gmo_api_key, settings.gmo_api_secret)
+    ws_supervisor = GMOWebSocketSupervisor(gmo_client, symbol="BTC_JPY")
+    process_lock = asyncio.Lock()
+
+    app.state.settings = settings
+    app.state.runtime = runtime_state
+    app.state.notifier = notifier
+    app.state.gmo = gmo_client
+    app.state.ws = ws_supervisor
+    app.state.process_lock = process_lock
+
+    @app.on_event("startup")
+    async def on_startup() -> None:  # pragma: no cover
+        logger.info("startup_begin", env=settings.env)
+        await ws_supervisor.start()
+        logger.info("startup_complete")
+
+    @app.on_event("shutdown")
+    async def on_shutdown() -> None:  # pragma: no cover
+        logger.info("shutdown_begin")
+        await ws_supervisor.stop()
+        await notifier.close()
+        await gmo_client.close()
+        logger.info("shutdown_complete")
+
+    async def get_payload(request: Request) -> WebhookPayloadType:
+        try:
+            body = await request.json()
+        except Exception as exc:  # pragma: no cover - FastAPI handles content-type errors
+            raise HTTPException(status_code=400, detail="invalid json") from exc
+        try:
+            return PayloadAdapter.validate_python(body)
+        except ValidationError as exc:  # pragma: no cover - fastapi handles but keep explicit
+            raise HTTPException(status_code=400, detail=exc.errors()) from exc
+
+    async def enforce_token(payload: WebhookBase) -> None:
+        if payload.token != settings.webhook_token:
+            logger.warning("webhook_token_mismatch", event_id=payload.event_id)
+            raise HTTPException(status_code=400, detail="token mismatch")
+
+    @app.get("/healthz")
+    async def healthz() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/status")
+    async def status() -> dict[str, Any]:
+        state = await runtime_state.get_status()
+        state["ws_connected"] = ws_supervisor.connected
+        return state
+
+    @app.post("/webhook", response_model=WebhookResponse)
+    async def webhook(payload: WebhookPayloadType = Depends(get_payload)) -> WebhookResponse:
+        await enforce_token(payload)
+        if payload.symbol not in settings.allowed_symbols:
+            raise HTTPException(status_code=400, detail="symbol not allowed")
+
+        try:
+            runtime_state.ensure_fresh(payload.ts)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        if await runtime_state.is_duplicate(payload.event_id):
+            logger.info("duplicate_event", event_id=payload.event_id)
+            return WebhookResponse(status="duplicate", event_id=payload.event_id, mode=payload.mode)
+
+        start_time = time.perf_counter()
+        async with process_lock:
+            if await runtime_state.is_duplicate(payload.event_id):
+                return WebhookResponse(status="duplicate", event_id=payload.event_id, mode=payload.mode)
+
+            if payload.mode == "ENTRY":
+                response = await handle_entry(payload, runtime_state, gmo_client, notifier)
+            else:
+                response = await handle_close(payload, runtime_state, gmo_client, notifier)
+
+            await runtime_state.record_event(
+                EventRecord(event_id=payload.event_id, ts=payload.ts, mode=payload.mode)
+            )
+
+        latency_ms = (time.perf_counter() - start_time) * 1000
+        response.latency_ms = latency_ms
+        return response
+
+    async def handle_entry(
+        payload: EntryPayload,
+        runtime_state: RuntimeState,
+        gmo_client: GMOCoinClient,
+        notifier: DiscordNotifier,
+    ) -> WebhookResponse:
+        try:
+            summary = await gmo_client.get_position_summary(payload.symbol)
+            runtime_state.record_retry("position_fetch", True)
+        except GMOCoinError as exc:
+            runtime_state.record_retry("position_fetch", False)
+            await notifier.notify_error(
+                title="ENTRY ERROR",
+                description=f"event_id={payload.event_id} position fetch failed",
+                fields={"code": exc.code, "status": exc.status},
+            )
+            raise HTTPException(status_code=502, detail="position fetch failed") from exc
+        await runtime_state.update_position(summary.net_side, summary.net_qty)
+        if not summary.is_flat and runtime_state.entry_policy == "ignore":
+            logger.info(
+                "entry_ignored_active_position",
+                event_id=payload.event_id,
+                current_side=summary.net_side,
+                current_qty=summary.net_qty,
+            )
+            return WebhookResponse(
+                status="ignored",
+                event_id=payload.event_id,
+                mode=payload.mode,
+                detail="position already open",
+            )
+
+        qty = runtime_state.floor_qty(payload.size)
+        if qty <= 0:
+            raise HTTPException(status_code=400, detail="size below qty_step")
+
+        try:
+            result = await gmo_client.place_market_order(payload.symbol, payload.side, qty)
+            runtime_state.record_retry("entry_order", True)
+        except GMOCoinError as exc:
+            runtime_state.record_retry("entry_order", False)
+            await notifier.notify_error(
+                title="ENTRY ERROR",
+                description=f"event_id={payload.event_id}",
+                fields={"code": exc.code, "status": exc.status, "retryable": exc.retryable},
+            )
+            raise HTTPException(status_code=502, detail="entry order failed") from exc
+
+        confirmed = await gmo_client.wait_until_position_matches(payload.symbol, payload.side, qty)
+        if confirmed.net_side != payload.side or abs(confirmed.net_qty - qty) > 1e-6:
+            logger.warning(
+                "entry_confirmation_mismatch",
+                event_id=payload.event_id,
+                expected_side=payload.side,
+                expected_qty=qty,
+                confirmed_side=confirmed.net_side,
+                confirmed_qty=confirmed.net_qty,
+            )
+        await runtime_state.update_position(confirmed.net_side, confirmed.net_qty)
+
+        await notifier.notify_success(
+            title="ENTRY OK",
+            description=f"event_id={payload.event_id} side={payload.side}",
+            fields={
+                "size": qty,
+                "net_side": confirmed.net_side or "FLAT",
+                "net_qty": confirmed.net_qty,
+            },
+        )
+
+        logger.info(
+            "entry_completed",
+            event_id=payload.event_id,
+            side=payload.side,
+            size=qty,
+            result=result,
+        )
+        return WebhookResponse(status="ok", event_id=payload.event_id, mode=payload.mode)
+
+    async def handle_close(
+        payload: ClosePayload,
+        runtime_state: RuntimeState,
+        gmo_client: GMOCoinClient,
+        notifier: DiscordNotifier,
+    ) -> WebhookResponse:
+        try:
+            summary = await gmo_client.get_position_summary(payload.symbol)
+            runtime_state.record_retry("position_fetch", True)
+        except GMOCoinError as exc:
+            runtime_state.record_retry("position_fetch", False)
+            await notifier.notify_error(
+                title="CLOSE ERROR",
+                description=f"event_id={payload.event_id} position fetch failed",
+                fields={"code": exc.code, "status": exc.status},
+            )
+            raise HTTPException(status_code=502, detail="position fetch failed") from exc
+        await runtime_state.update_position(summary.net_side, summary.net_qty)
+        if summary.is_flat:
+            await notifier.notify_success(
+                title="CLOSE OK",
+                description=f"event_id={payload.event_id} already flat",
+                fields={"closed_qty": 0, "avg_px": "n/a"},
+            )
+            logger.info("close_already_flat", event_id=payload.event_id)
+            return WebhookResponse(status="ok", event_id=payload.event_id, mode=payload.mode, detail="already flat")
+
+        opposite_side = "SELL" if summary.net_side == "BUY" else "BUY"
+        closed_qty = 0.0
+        for position in summary.positions:
+            position_size = float(position.get("size") or position.get("positionSize") or 0.0)
+            if position_size <= 0:
+                continue
+            try:
+                await gmo_client.place_market_order(
+                    payload.symbol,
+                    opposite_side,
+                    position_size,
+                    settle_positions=[position],
+                )
+                runtime_state.record_retry("close_order", True)
+                closed_qty += position_size
+            except GMOCoinError as exc:
+                runtime_state.record_retry("close_order", False)
+                if exc.retryable:
+                    raise HTTPException(status_code=502, detail="close order retryable failure") from exc
+                await notifier.notify_error(
+                    title="CLOSE ERROR",
+                    description=f"event_id={payload.event_id}",
+                    fields={"code": exc.code, "status": exc.status},
+                )
+                raise HTTPException(status_code=502, detail="close order failed") from exc
+
+        confirmed = await gmo_client.wait_until_position_matches(payload.symbol, None, 0.0)
+        if not confirmed.is_flat:
+            logger.warning(
+                "close_confirmation_mismatch",
+                event_id=payload.event_id,
+                final_side=confirmed.net_side,
+                final_qty=confirmed.net_qty,
+            )
+        await runtime_state.update_position(confirmed.net_side, confirmed.net_qty)
+
+        await notifier.notify_success(
+            title="CLOSE OK",
+            description=f"event_id={payload.event_id}",
+            fields={
+                "closed_qty": round(closed_qty, 8),
+                "avg_px": "market",
+                "net_qty": confirmed.net_qty,
+            },
+        )
+
+        logger.info(
+            "close_completed",
+            event_id=payload.event_id,
+            closed_qty=closed_qty,
+            final_side=confirmed.net_side,
+            final_qty=confirmed.net_qty,
+        )
+        return WebhookResponse(status="ok", event_id=payload.event_id, mode=payload.mode)
+
+    return app
+
+
+app = create_app()
+

--- a/btcjpy-entry-close-bot/exec-lane/gmo.py
+++ b/btcjpy-entry-close-bot/exec-lane/gmo.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import asyncio
+import math
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List, Literal, Optional, Sequence
+
+import pybotters
+
+
+def _format_size(size: float) -> str:
+    text = format(size, ".8f")
+    text = text.rstrip("0").rstrip(".")
+    return text or "0"
+
+
+class GMOCoinError(Exception):
+    def __init__(self, message: str, *, status: Optional[int] = None, code: Optional[str] = None, retryable: bool = False, data: Optional[dict] = None) -> None:
+        super().__init__(message)
+        self.status = status
+        self.code = code
+        self.retryable = retryable
+        self.data = data or {}
+
+
+@dataclass
+class PositionSummary:
+    symbol: str
+    net_side: Optional[Literal["BUY", "SELL"]]
+    net_qty: float
+    positions: List[dict]
+
+    @property
+    def is_flat(self) -> bool:
+        return self.net_qty == 0 or self.net_side is None
+
+
+class GMOCoinClient:
+    BASE_URL = "https://api.coin.z.com"
+
+    def __init__(self, api_key: str, api_secret: str, *, base_url: Optional[str] = None) -> None:
+        self._client = pybotters.Client(
+            apis={"gmocoin": [api_key, api_secret]},
+            base_url=base_url or self.BASE_URL,
+        )
+
+    async def close(self) -> None:
+        await self._client.close()
+
+    async def _request_with_retry(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: Optional[dict] = None,
+        json: Optional[dict] = None,
+        name: str,
+    ) -> dict:
+        delays = [0.5, 1.0, 2.0]
+        last_err: Optional[GMOCoinError] = None
+        for attempt, delay in enumerate(delays, start=1):
+            try:
+                async with self._client.request(method, url, params=params, json=json, timeout=30) as resp:
+                    data = await resp.json()
+            except asyncio.TimeoutError as exc:
+                last_err = GMOCoinError(
+                    f"{name} timeout",
+                    status=None,
+                    code="timeout",
+                    retryable=True,
+                    data={"attempt": attempt},
+                )
+            else:
+                status = resp.status
+                api_status = data.get("status")
+                if status in (429,) or status >= 500:
+                    last_err = GMOCoinError(
+                        f"{name} http_error",
+                        status=status,
+                        code=str(api_status),
+                        retryable=True,
+                        data={"attempt": attempt, "body": data},
+                    )
+                elif status >= 400:
+                    raise GMOCoinError(
+                        f"{name} client_error",
+                        status=status,
+                        code=str(api_status),
+                        retryable=False,
+                        data={"body": data},
+                    )
+                elif api_status not in (0, "0", None, "success"):
+                    raise GMOCoinError(
+                        f"{name} api_error",
+                        status=status,
+                        code=str(api_status),
+                        retryable=False,
+                        data={"body": data},
+                    )
+                else:
+                    return data
+            await asyncio.sleep(delay)
+        assert last_err is not None
+        raise last_err
+
+    async def get_open_positions(self, symbol: str) -> List[dict]:
+        data = await self._request_with_retry(
+            "GET",
+            "/private/v1/openPositions",
+            params={"symbol": symbol, "page": 1, "count": 100},
+            name="get_open_positions",
+        )
+        positions = data.get("data") or []
+        return positions
+
+    async def get_position_summary(self, symbol: str) -> PositionSummary:
+        positions = await self.get_open_positions(symbol)
+        long_qty = 0.0
+        short_qty = 0.0
+        for pos in positions:
+            side = pos.get("side")
+            qty = float(pos.get("size") or pos.get("positionSize") or 0.0)
+            if side == "BUY":
+                long_qty += qty
+            elif side == "SELL":
+                short_qty += qty
+        net = long_qty - short_qty
+        if math.isclose(net, 0.0, abs_tol=1e-9):
+            net_side: Optional[Literal["BUY", "SELL"]] = None
+            net_qty = 0.0
+        elif net > 0:
+            net_side = "BUY"
+            net_qty = round(net, 8)
+        else:
+            net_side = "SELL"
+            net_qty = round(abs(net), 8)
+        return PositionSummary(symbol=symbol, net_side=net_side, net_qty=net_qty, positions=positions)
+
+    async def place_market_order(
+        self,
+        symbol: str,
+        side: Literal["BUY", "SELL"],
+        size: float,
+        *,
+        settle_positions: Optional[Sequence[dict]] = None,
+        time_in_force: str = "FAS",
+    ) -> dict:
+        payload: Dict[str, Any] = {
+            "symbol": symbol,
+            "side": side,
+            "executionType": "MARKET",
+            "timeInForce": time_in_force,
+            "size": _format_size(size),
+        }
+        if settle_positions:
+            payload["settlePositionPositionId"] = [
+                {
+                    "positionId": p["positionId"],
+                    "settlePositionSize": _format_size(float(p["size"])),
+                }
+                for p in settle_positions
+                if p.get("positionId") and float(p.get("size", 0)) > 0
+            ]
+        return await self._request_with_retry(
+            "POST",
+            "/private/v1/order",
+            json=payload,
+            name="place_market_order",
+        )
+
+    async def wait_until_position_matches(
+        self,
+        symbol: str,
+        expected_side: Optional[Literal["BUY", "SELL"]],
+        expected_qty: float,
+        *,
+        timeout: float = 10.0,
+        poll_interval: float = 0.5,
+    ) -> PositionSummary:
+        deadline = time.monotonic() + timeout
+        last_summary: Optional[PositionSummary] = None
+        while time.monotonic() < deadline:
+            summary = await self.get_position_summary(symbol)
+            last_summary = summary
+            if expected_side is None:
+                if summary.is_flat:
+                    return summary
+            else:
+                if summary.net_side == expected_side and math.isclose(summary.net_qty, expected_qty, rel_tol=1e-6, abs_tol=1e-6):
+                    return summary
+            await asyncio.sleep(poll_interval)
+        return last_summary or PositionSummary(symbol=symbol, net_side=None, net_qty=0.0, positions=[])
+

--- a/btcjpy-entry-close-bot/exec-lane/notify.py
+++ b/btcjpy-entry-close-bot/exec-lane/notify.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, Optional
+
+import httpx
+from loguru import logger
+
+
+class DiscordNotifier:
+    def __init__(self, webhook_url: Optional[str], *, timeout: float = 10.0) -> None:
+        self._webhook_url = webhook_url
+        self._client = httpx.AsyncClient(timeout=httpx.Timeout(timeout)) if webhook_url else None
+        self._lock = asyncio.Lock()
+
+    async def close(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+
+    async def send(
+        self,
+        *,
+        title: str,
+        description: str,
+        color: int,
+        fields: Optional[Dict[str, Any]] = None,
+        footer: Optional[str] = None,
+    ) -> None:
+        if not self._webhook_url or not self._client:
+            logger.debug("discord_webhook_disabled", title=title)
+            return
+        embed_fields = []
+        if fields:
+            for name, value in fields.items():
+                embed_fields.append({"name": name, "value": str(value), "inline": True})
+        payload = {
+            "embeds": [
+                {
+                    "title": title,
+                    "description": description,
+                    "color": color,
+                    "fields": embed_fields,
+                    "footer": {"text": footer or "btcjpy-entry-close-bot"},
+                }
+            ]
+        }
+        async with self._lock:
+            response = await self._client.post(self._webhook_url, json=payload)
+            if response.status_code >= 400:
+                logger.error(
+                    "discord_notification_failed",
+                    status_code=response.status_code,
+                    body=response.text,
+                )
+
+    async def notify_success(self, title: str, description: str, fields: Optional[Dict[str, Any]] = None) -> None:
+        await self.send(title=title, description=description, color=0x2ecc71, fields=fields)
+
+    async def notify_warning(self, title: str, description: str, fields: Optional[Dict[str, Any]] = None) -> None:
+        await self.send(title=title, description=description, color=0xf1c40f, fields=fields)
+
+    async def notify_error(self, title: str, description: str, fields: Optional[Dict[str, Any]] = None) -> None:
+        await self.send(title=title, description=description, color=0xe74c3c, fields=fields)
+

--- a/btcjpy-entry-close-bot/exec-lane/requirements.txt
+++ b/btcjpy-entry-close-bot/exec-lane/requirements.txt
@@ -1,0 +1,9 @@
+fastapi==0.110.2
+uvicorn[standard]==0.29.0
+uvloop==0.19.0
+pybotters==1.1.0
+httpx==0.27.0
+python-dotenv==1.0.1
+pydantic==2.6.4
+loguru==0.7.2
+orjson==3.10.0

--- a/btcjpy-entry-close-bot/exec-lane/runtime.py
+++ b/btcjpy-entry-close-bot/exec-lane/runtime.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import asyncio
+import math
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+@dataclass
+class EventRecord:
+    event_id: str
+    ts: datetime
+    mode: str
+
+
+class RuntimeState:
+    def __init__(
+        self,
+        *,
+        db_path: Path,
+        max_skew_seconds: int,
+        qty_step: float,
+        entry_policy: str,
+    ) -> None:
+        self._db_path = db_path
+        self._max_skew_seconds = max_skew_seconds
+        self._qty_step = qty_step
+        self._entry_policy = entry_policy
+        self._lock = asyncio.Lock()
+        self._last_event_id: Optional[str] = None
+        self._last_event_ts: Optional[datetime] = None
+        self._position_side: Optional[str] = None
+        self._position_qty: float = 0.0
+        self._retry_stats: Dict[str, Dict[str, int]] = {}
+        self._init_db()
+
+    def _init_db(self) -> None:
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(self._db_path)
+        try:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS events (
+                    event_id TEXT PRIMARY KEY,
+                    ts TEXT NOT NULL,
+                    mode TEXT NOT NULL,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS state (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL
+                )
+                """
+            )
+            conn.commit()
+            row = conn.execute(
+                "SELECT event_id, ts FROM events ORDER BY created_at DESC LIMIT 1"
+            ).fetchone()
+            if row:
+                self._last_event_id = row[0]
+                try:
+                    self._last_event_ts = datetime.fromisoformat(row[1])
+                except ValueError:
+                    self._last_event_ts = None
+        finally:
+            conn.close()
+
+    async def _run_db(self, query: str, params: tuple = (), fetchone: bool = False) -> Any:
+        def _execute() -> Any:
+            conn = sqlite3.connect(self._db_path)
+            try:
+                cur = conn.execute(query, params)
+                conn.commit()
+                if fetchone:
+                    return cur.fetchone()
+                return cur.fetchall()
+            finally:
+                conn.close()
+
+        return await asyncio.to_thread(_execute)
+
+    async def record_event(self, event: EventRecord) -> None:
+        await self._run_db(
+            "INSERT OR REPLACE INTO events(event_id, ts, mode) VALUES (?, ?, ?)",
+            (event.event_id, event.ts.isoformat(), event.mode),
+        )
+        async with self._lock:
+            self._last_event_id = event.event_id
+            self._last_event_ts = event.ts
+
+    async def is_duplicate(self, event_id: str) -> bool:
+        row = await self._run_db(
+            "SELECT event_id FROM events WHERE event_id = ?",
+            (event_id,),
+            fetchone=True,
+        )
+        return row is not None
+
+    def ensure_fresh(self, ts: datetime) -> None:
+        now = datetime.now(timezone.utc)
+        delta = abs((now - ts).total_seconds())
+        if delta > self._max_skew_seconds:
+            raise ValueError(f"timestamp_skew_exceeded: {delta:.2f}s > {self._max_skew_seconds}s")
+
+    def floor_qty(self, size: float) -> float:
+        if size <= 0:
+            return 0.0
+        steps = math.floor(size / self._qty_step)
+        return round(steps * self._qty_step, 8)
+
+    async def update_position(self, side: Optional[str], qty: float) -> None:
+        async with self._lock:
+            self._position_side = side
+            self._position_qty = qty
+
+    async def get_status(self) -> Dict[str, Any]:
+        async with self._lock:
+            status = {
+                "position_side": self._position_side,
+                "position_qty": self._position_qty,
+                "last_event_id": self._last_event_id,
+                "last_event_ts": self._last_event_ts.isoformat() if self._last_event_ts else None,
+                "retry_stats": self._retry_stats,
+            }
+        return status
+
+    def record_retry(self, key: str, success: bool) -> None:
+        bucket = self._retry_stats.setdefault(key, {"success": 0, "failure": 0})
+        bucket["success" if success else "failure"] += 1
+
+    @property
+    def entry_policy(self) -> str:
+        return self._entry_policy
+
+    @property
+    def max_skew_seconds(self) -> int:
+        return self._max_skew_seconds
+
+    @property
+    def qty_step(self) -> float:
+        return self._qty_step
+

--- a/btcjpy-entry-close-bot/exec-lane/ws.py
+++ b/btcjpy-entry-close-bot/exec-lane/ws.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from typing import Optional
+
+from loguru import logger
+
+try:
+    from pybotters.helpers.gmocoin import GMOCoinHelper
+except Exception:  # pragma: no cover - optional dependency for runtime only
+    GMOCoinHelper = None  # type: ignore
+
+
+class GMOWebSocketSupervisor:
+    """Minimal supervisor to track WS connectivity (v1 placeholder)."""
+
+    def __init__(self, client, symbol: str) -> None:
+        self._client = client
+        self._symbol = symbol
+        self._connected = asyncio.Event()
+        self._task: Optional[asyncio.Task] = None
+
+    @property
+    def connected(self) -> bool:
+        return self._connected.is_set()
+
+    async def start(self) -> None:
+        if GMOCoinHelper is None:
+            logger.warning("gmocoin_helper_unavailable", reason="pybotters extras not installed")
+            return
+        if self._task is None:
+            self._task = asyncio.create_task(self._run(), name="gmocoin-ws")
+
+    async def stop(self) -> None:
+        if self._task:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None
+            self._connected.clear()
+
+    async def _run(self) -> None:
+        helper = GMOCoinHelper(self._client._client)  # type: ignore[attr-defined]
+        try:
+            async with helper.trade_ws(symbols=[self._symbol]) as ws:
+                self._connected.set()
+                async for _ in ws:
+                    pass
+        except Exception as exc:
+            logger.error("gmocoin_ws_error", error=str(exc))
+        finally:
+            self._connected.clear()
+


### PR DESCRIPTION
## Summary
- add containerised FastAPI service that ingests TradingView webhooks and drives GMO Coin orders via pybotters with Discord notifications
- implement runtime management including SQLite-backed idempotency, retry metrics, and quantity rounding logic complying with ENTRY ignore policy
- document full deployment procedure covering ConoHa VPS, Cloudflared exposure, smoke tests, and operational tips

## Testing
- python -m compileall btcjpy-entry-close-bot/exec-lane

------
https://chatgpt.com/codex/tasks/task_e_68d46dbf85b083229102409d3575355b