### PR TITLE
Implement FastAPI webhook bridge for GMO Coin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
-# TradingView-GMOcoin-bot
+# TradingView GMOcoin Bot
+
+FastAPI-based webhook receiver that relays TradingView alerts to GMO Coin via `pybotters`. The bot enforces single-position trading for `BTC_JPY`, quantises order sizes, and notifies Discord about execution outcomes.
+
+## Features
+
+- `POST /webhook` authenticates TradingView alerts via a shared token, idempotency cache, and timestamp skew validation.
+- `ENTRY` alerts submit market orders when no position is open; existing positions are ignored per policy.
+- `CLOSE` alerts flatten any open position with market orders and confirm fills by polling open positions.
+- Retry logic for transient GMO API failures (HTTP 429/5xx) with exponential backoff.
+- Optional Discord webhook notifications for success and error events.
+- `GET /healthz` and `GET /status` endpoints for health checks and runtime diagnostics.
+
+## Configuration
+
+Environment variables:
+
+| Variable | Description |
+| --- | --- |
+| `WEBHOOK_TOKEN` | Shared secret used to authenticate TradingView alerts. |
+| `GMO_API_KEY` / `GMO_API_SECRET` | GMO Coin API credentials (32 / 64 characters). |
+| `ALLOWED_SYMBOLS` | Comma-separated list of allowed symbols (defaults to `BTC_JPY`). |
+| `ENTRY_POLICY` | Must be `ignore`. Existing positions suppress new entries. |
+| `MAX_SKEW_SECONDS` | Maximum allowed skew between alert timestamp and server (default `60`). |
+| `QTY_STEP` | Minimum quantity step (default `0.01`). |
+| `DISCORD_WEBHOOK_URL` | Optional Discord webhook for notifications. |
+| `ENV` | Environment label for logging (default `dev`). |
+| `IDEMPOTENCY_TTL_SECONDS` | Lifetime for cached event IDs (default `600`). |
+| `STATUS_CACHE_SIZE` | Number of recent events kept for `/status` (default `100`). |
+
+## Running locally
+
+```bash
+pip install -r requirements.txt
+uvicorn app.app:app --host 0.0.0.0 --port 8000
+```
+
+## Testing webhook
+
+```bash
+curl -iS http://localhost:8000/webhook \
+  -H "Content-Type: application/json" \
+  --data-binary '{
+    "token":"SECRETxxyyzz",
+    "event_id":"dev-ENTRY-001",
+    "ts":"2025-09-24T00:00:00Z",
+    "mode":"ENTRY",
+    "symbol":"BTC_JPY",
+    "side":"BUY",
+    "size":0.04
+  }'
+```

--- a/app/app.py
+++ b/app/app.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from typing import Any, Deque, Dict
+
+from fastapi import Depends, FastAPI, HTTPException, Request, status
+from fastapi.responses import JSONResponse
+from loguru import logger
+
+from app.config import Settings, get_settings
+from app.idempotency import IdempotencyCache
+from app.models import ClosePayload, EntryPayload, StatusSnapshot, WebhookResponse
+from app.services.gmo import GmoCoinService
+from app.services.notifier import DiscordNotifier
+from app.utils import parse_iso8601_z, quantize, utcnow
+
+app = FastAPI(title="TradingView GMOcoin Bot", version="1.0.0")
+
+
+class AppState:
+    def __init__(self, settings: Settings) -> None:
+        self.settings = settings
+        self.idempotency = IdempotencyCache(ttl_seconds=settings.idempotency_ttl_seconds)
+        self.gmo = GmoCoinService(settings)
+        self.notifier = DiscordNotifier(settings.discord_webhook_url)
+        self.operation_lock = asyncio.Lock()
+        self.last_events: Deque[Dict[str, Any]] = deque(maxlen=settings.status_cache_size)
+
+
+@app.on_event("startup")
+async def on_startup(settings: Settings = Depends(get_settings)) -> None:
+    app.state.runtime = AppState(settings)
+    logger.info("Starting services for environment=%s", settings.env)
+    await app.state.runtime.gmo.start()
+    await app.state.runtime.notifier.start()
+
+
+@app.on_event("shutdown")
+async def on_shutdown() -> None:
+    runtime: AppState = app.state.runtime
+    await runtime.gmo.stop()
+    await runtime.notifier.stop()
+
+
+@app.get("/healthz")
+async def healthz() -> Dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/status", response_model=StatusSnapshot)
+async def status_endpoint() -> StatusSnapshot:
+    runtime: AppState = app.state.runtime
+    position = await runtime.gmo.get_position("BTC_JPY")
+    events = list(runtime.last_events)
+    return StatusSnapshot(
+        position_size=position.size,
+        position_side=position.side,
+        last_events=events,
+        websocket_connected=runtime.gmo.websocket_connected,
+        retries=runtime.gmo.retry_stats,
+    )
+
+
+@app.post("/webhook", response_model=WebhookResponse)
+async def webhook_endpoint(request: Request) -> JSONResponse:
+    payload_data = await request.json()
+    mode = payload_data.get("mode")
+    runtime: AppState = app.state.runtime
+    settings = runtime.settings
+
+    if mode == "ENTRY":
+        payload = EntryPayload(**payload_data)
+    elif mode == "CLOSE":
+        payload = ClosePayload(**payload_data)
+    else:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid mode")
+
+    if payload.token != settings.webhook_token:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+    if payload.symbol not in settings.allowed_symbol_set:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Symbol not allowed")
+
+    event_time = parse_iso8601_z(payload.ts)
+    now = utcnow()
+    skew = abs((now - event_time).total_seconds())
+    if skew > settings.max_skew_seconds:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Event timestamp skew too large")
+
+    added = await runtime.idempotency.add(payload.event_id, payload.mode, payload.symbol)
+    if not added:
+        logger.info("Duplicate event received event_id=%s", payload.event_id)
+        return JSONResponse(
+            status_code=status.HTTP_200_OK,
+            content=WebhookResponse(
+                status="duplicate",
+                detail="Event already processed",
+                ignored=True,
+                event_id=payload.event_id,
+            ).dict(),
+        )
+
+    latency_ms = int((now - event_time).total_seconds() * 1000)
+
+    if mode == "ENTRY":
+        response = await _handle_entry(runtime, payload, latency_ms)
+    else:
+        response = await _handle_close(runtime, payload, latency_ms)
+    return response
+
+
+async def _handle_entry(runtime: AppState, payload: EntryPayload, latency_ms: int) -> JSONResponse:
+    size = quantize(payload.size, runtime.settings.qty_step)
+    if size <= 0:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Size below minimum step")
+
+    async with runtime.operation_lock:
+        position = await runtime.gmo.get_position(payload.symbol)
+        if position.size > 0:
+            logger.info(
+                "ENTRY ignored due to existing position size=%s side=%s", position.size, position.side
+            )
+            return JSONResponse(
+                status_code=status.HTTP_200_OK,
+                content=WebhookResponse(
+                    status="ignored",
+                    detail="Position already open",
+                    ignored=True,
+                    event_id=payload.event_id,
+                ).dict(),
+            )
+        try:
+            response = await runtime.gmo.place_entry(payload.symbol, payload.side, size)
+        except Exception as exc:  # noqa: BLE001
+            await runtime.notifier.notify(
+                f"ERROR | id={payload.event_id} mode=ENTRY msg={exc}"
+            )
+            raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)) from exc
+
+    avg_price = _extract_average_price(response)
+    message = (
+        f"ENTRY OK | id={payload.event_id} sym={payload.symbol} side={payload.side} "
+        f"size={size:.8f} avg_px={avg_price or 'n/a'} latency={latency_ms}ms"
+    )
+    await runtime.notifier.notify(message)
+    _record_event(runtime, {
+        "event_id": payload.event_id,
+        "mode": payload.mode,
+        "side": payload.side,
+        "size": size,
+        "timestamp": utcnow().isoformat(),
+        "message": message,
+    })
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content=WebhookResponse(
+            status="ok",
+            detail="Entry executed",
+            ignored=False,
+            event_id=payload.event_id,
+        ).dict(),
+    )
+
+
+async def _handle_close(runtime: AppState, payload: ClosePayload, latency_ms: int) -> JSONResponse:
+    async with runtime.operation_lock:
+        position = await runtime.gmo.get_position(payload.symbol)
+        if position.size <= 0:
+            logger.info("CLOSE noop no open position")
+            message = (
+                f"CLOSE OK | id={payload.event_id} sym={payload.symbol} closed=0 avg_px=n/a "
+                f"pnl=0 latency={latency_ms}ms"
+            )
+            await runtime.notifier.notify(message)
+            _record_event(runtime, {
+                "event_id": payload.event_id,
+                "mode": payload.mode,
+                "closed": 0,
+                "timestamp": utcnow().isoformat(),
+                "message": message,
+            })
+            return JSONResponse(
+                status_code=status.HTTP_200_OK,
+                content=WebhookResponse(
+                    status="ok",
+                    detail="No position to close",
+                    ignored=False,
+                    event_id=payload.event_id,
+                ).dict(),
+            )
+        close_side = "SELL" if position.side == "BUY" else "BUY"
+        try:
+            response = await runtime.gmo.close_position(payload.symbol, close_side, position.size)
+        except Exception as exc:  # noqa: BLE001
+            await runtime.notifier.notify(
+                f"ERROR | id={payload.event_id} mode=CLOSE msg={exc}"
+            )
+            raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)) from exc
+
+    avg_price = _extract_average_price(response)
+    pnl = _extract_pnl(response)
+    message = (
+        f"CLOSE OK | id={payload.event_id} sym={payload.symbol} closed={position.size:.8f} "
+        f"avg_px={avg_price or 'n/a'} pnl={pnl if pnl is not None else 'n/a'} latency={latency_ms}ms"
+    )
+    await runtime.notifier.notify(message)
+    _record_event(runtime, {
+        "event_id": payload.event_id,
+        "mode": payload.mode,
+        "closed": position.size,
+        "timestamp": utcnow().isoformat(),
+        "message": message,
+    })
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content=WebhookResponse(
+            status="ok",
+            detail="Position closed",
+            ignored=False,
+            event_id=payload.event_id,
+        ).dict(),
+    )
+
+
+def _record_event(runtime: AppState, event: Dict[str, Any]) -> None:
+    runtime.last_events.append(event)
+
+
+def _extract_average_price(response: Dict[str, Any]) -> Any:
+    data = response.get("data") if isinstance(response, dict) else None
+    if isinstance(data, dict):
+        return data.get("price") or data.get("avgPrice") or data.get("averagePrice")
+    if isinstance(data, list) and data:
+        candidate = data[0]
+        if isinstance(candidate, dict):
+            return candidate.get("price") or candidate.get("avgPrice") or candidate.get("averagePrice")
+    return None
+
+
+def _extract_pnl(response: Dict[str, Any]) -> Any:
+    data = response.get("data") if isinstance(response, dict) else None
+    if isinstance(data, dict):
+        return data.get("pnl") or data.get("profitLoss")
+    if isinstance(data, list) and data:
+        candidate = data[0]
+        if isinstance(candidate, dict):
+            return candidate.get("pnl") or candidate.get("profitLoss")
+    return None

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Optional, Set
+
+from pydantic import BaseSettings, Field, validator
+
+
+class Settings(BaseSettings):
+    webhook_token: str = Field(..., env="WEBHOOK_TOKEN")
+    gmo_api_key: str = Field(..., env="GMO_API_KEY")
+    gmo_api_secret: str = Field(..., env="GMO_API_SECRET")
+    allowed_symbols: str = Field("BTC_JPY", env="ALLOWED_SYMBOLS")
+    entry_policy: str = Field("ignore", env="ENTRY_POLICY")
+    max_skew_seconds: int = Field(60, env="MAX_SKEW_SECONDS")
+    qty_step: float = Field(0.01, env="QTY_STEP")
+    discord_webhook_url: Optional[str] = Field(None, env="DISCORD_WEBHOOK_URL")
+    env: str = Field("dev", env="ENV")
+    idempotency_ttl_seconds: int = Field(600, env="IDEMPOTENCY_TTL_SECONDS")
+    status_cache_size: int = Field(100, env="STATUS_CACHE_SIZE")
+    gmo_base_url: str = Field("https://api.coin.z.com", env="GMO_BASE_URL")
+
+    @validator("entry_policy")
+    def validate_entry_policy(cls, value: str) -> str:
+        normalized = value.lower()
+        if normalized not in {"ignore"}:
+            raise ValueError("ENTRY_POLICY must be 'ignore'")
+        return normalized
+
+    @validator("allowed_symbols")
+    def normalize_symbols(cls, value: str) -> str:
+        return value.replace(" ", "")
+
+    @property
+    def allowed_symbol_set(self) -> Set[str]:
+        return {symbol for symbol in self.allowed_symbols.split(",") if symbol}
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    return Settings()

--- a/app/idempotency.py
+++ b/app/idempotency.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Optional
+
+
+@dataclass
+class EventRecord:
+    event_id: str
+    mode: str
+    symbol: str
+    created_at: datetime
+
+
+class IdempotencyCache:
+    def __init__(self, ttl_seconds: int = 600) -> None:
+        self._ttl = timedelta(seconds=ttl_seconds)
+        self._events: Dict[str, EventRecord] = {}
+        self._lock = asyncio.Lock()
+
+    async def add(self, event_id: str, mode: str, symbol: str) -> bool:
+        async with self._lock:
+            self._purge()
+            if event_id in self._events:
+                return False
+            self._events[event_id] = EventRecord(
+                event_id=event_id,
+                mode=mode,
+                symbol=symbol,
+                created_at=datetime.now(timezone.utc),
+            )
+            return True
+
+    async def exists(self, event_id: str) -> bool:
+        async with self._lock:
+            self._purge()
+            return event_id in self._events
+
+    async def get(self, event_id: str) -> Optional[EventRecord]:
+        async with self._lock:
+            self._purge()
+            return self._events.get(event_id)
+
+    async def snapshot(self) -> Dict[str, EventRecord]:
+        async with self._lock:
+            self._purge()
+            return dict(self._events)
+
+    def _purge(self) -> None:
+        now = datetime.now(timezone.utc)
+        expired = [key for key, record in self._events.items() if now - record.created_at > self._ttl]
+        for key in expired:
+            self._events.pop(key, None)

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field, validator
+
+
+class WebhookBase(BaseModel):
+    token: str
+    event_id: str = Field(..., alias="event_id")
+    ts: str
+    mode: Literal["ENTRY", "CLOSE"]
+    symbol: str
+
+    @validator("ts")
+    def validate_ts(cls, value: str) -> str:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return value
+
+
+class EntryPayload(WebhookBase):
+    mode: Literal["ENTRY"]
+    side: Literal["BUY", "SELL"]
+    size: float
+
+
+class ClosePayload(WebhookBase):
+    mode: Literal["CLOSE"]
+    side: Optional[str] = None
+    size: Optional[float] = None
+
+
+class WebhookResponse(BaseModel):
+    status: str
+    detail: str
+    ignored: bool = False
+    event_id: str
+
+
+class StatusSnapshot(BaseModel):
+    position_size: float
+    position_side: Optional[str]
+    last_events: list
+    websocket_connected: bool
+    retries: dict

--- a/app/services/gmo.py
+++ b/app/services/gmo.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Any, Dict, Optional
+
+import pybotters
+from loguru import logger
+
+from app.config import Settings
+from app.utils import utcnow
+
+
+@dataclass
+class Position:
+    size: float
+    side: Optional[str]
+
+
+class GmoCoinService:
+    def __init__(self, settings: Settings) -> None:
+        self._settings = settings
+        self._client: Optional[pybotters.Client] = None
+        self._lock = asyncio.Lock()
+        self._retry_stats: Dict[str, int] = {"rest_retries": 0}
+        self._ws_connected = False
+
+    @property
+    def retry_stats(self) -> Dict[str, int]:
+        return dict(self._retry_stats)
+
+    @property
+    def websocket_connected(self) -> bool:
+        return self._ws_connected
+
+    async def start(self) -> None:
+        if self._client is not None:
+            return
+        self._client = pybotters.Client(
+            apis={"gmocoin": [self._settings.gmo_api_key, self._settings.gmo_api_secret]},
+            base_url=self._settings.gmo_base_url,
+        )
+        asyncio.create_task(self._noop_ws_guard())
+
+    async def stop(self) -> None:
+        if self._client is not None:
+            await self._client.close()
+            self._client = None
+        self._ws_connected = False
+
+    async def _noop_ws_guard(self) -> None:
+        # Placeholder guard to mark websocket status as unavailable
+        logger.info("WS monitor placeholder activated; no live WS connection established")
+        self._ws_connected = False
+
+    async def get_position(self, symbol: str) -> Position:
+        response = await self._request("get", "/private/v1/openPositions", params={"symbol": symbol})
+        data = response.get("data", [])
+        total_size = 0.0
+        side: Optional[str] = None
+        for item in data:
+            size = float(item.get("size", 0))
+            if size <= 0:
+                continue
+            total_size += size
+            side = item.get("side")
+        logger.debug("Fetched open position: size=%s side=%s", total_size, side)
+        return Position(size=total_size, side=side)
+
+    async def place_entry(self, symbol: str, side: str, size: float) -> Dict[str, Any]:
+        payload = {
+            "symbol": symbol,
+            "side": side,
+            "executionType": "MARKET",
+            "size": f"{size:.8f}",
+        }
+        response = await self._request("post", "/private/v1/order", json=payload)
+        await self._wait_for_fill(symbol, expected_size=size, target_side=side, timeout=10)
+        return response
+
+    async def close_position(self, symbol: str, side: str, size: float) -> Dict[str, Any]:
+        payload = {
+            "symbol": symbol,
+            "side": side,
+            "executionType": "MARKET",
+            "size": f"{size:.8f}",
+        }
+        response = await self._request("post", "/private/v1/closeBulkOrder", json=payload)
+        await self._wait_for_flat(symbol, timeout=10)
+        return response
+
+    async def _wait_for_fill(self, symbol: str, expected_size: float, target_side: str, timeout: int) -> None:
+        deadline = utcnow() + timedelta(seconds=timeout)
+        while utcnow() < deadline:
+            position = await self.get_position(symbol)
+            if position.size >= expected_size and position.side == target_side:
+                return
+            await asyncio.sleep(1)
+        logger.warning("Fill confirmation timeout for entry order")
+
+    async def _wait_for_flat(self, symbol: str, timeout: int) -> None:
+        deadline = utcnow() + timedelta(seconds=timeout)
+        while utcnow() < deadline:
+            position = await self.get_position(symbol)
+            if position.size == 0:
+                return
+            await asyncio.sleep(1)
+        logger.warning("Flat confirmation timeout for close order")
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
+        retries: int = 3,
+    ) -> Dict[str, Any]:
+        if self._client is None:
+            raise RuntimeError("GMO client not started")
+        attempt = 0
+        wait = 0.5
+        last_error: Optional[Exception] = None
+        while attempt < retries:
+            attempt += 1
+            try:
+                request = getattr(self._client, method)
+                should_retry = False
+                async with self._lock:
+                    async with request(path, params=params, json=json) as response:
+                        if response.status == 429 or response.status >= 500:
+                            text = await response.text()
+                            logger.warning(
+                                "GMO API transient error status=%s body=%s attempt=%s",
+                                response.status,
+                                text,
+                                attempt,
+                            )
+                            if attempt < retries:
+                                should_retry = True
+                            else:
+                                response.raise_for_status()
+                        elif 400 <= response.status < 500:
+                            text = await response.text()
+                            logger.error(
+                                "GMO API client error status=%s body=%s", response.status, text
+                            )
+                            response.raise_for_status()
+                        if should_retry:
+                            data = None
+                        else:
+                            data = await response.json()
+                if should_retry:
+                    self._retry_stats["rest_retries"] += 1
+                    await asyncio.sleep(wait)
+                    wait *= 2
+                    continue
+                logger.debug("GMO API response path=%s data=%s", path, data)
+                return data
+            except Exception as exc:  # noqa: BLE001
+                last_error = exc
+                logger.exception("GMO API request failed on attempt %s: %s", attempt, exc)
+                if attempt >= retries:
+                    break
+                self._retry_stats["rest_retries"] += 1
+                await asyncio.sleep(wait)
+                wait *= 2
+        if last_error:
+            raise last_error
+        raise RuntimeError("Unknown GMO request failure")

--- a/app/services/notifier.py
+++ b/app/services/notifier.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, Optional
+
+import aiohttp
+from loguru import logger
+
+
+class DiscordNotifier:
+    def __init__(self, webhook_url: Optional[str]) -> None:
+        self._webhook_url = webhook_url
+        self._session: Optional[aiohttp.ClientSession] = None
+        self._lock = asyncio.Lock()
+
+    async def start(self) -> None:
+        if self._webhook_url is None:
+            return
+        async with self._lock:
+            if self._session is None:
+                timeout = aiohttp.ClientTimeout(total=10)
+                self._session = aiohttp.ClientSession(timeout=timeout)
+
+    async def stop(self) -> None:
+        async with self._lock:
+            if self._session is not None:
+                await self._session.close()
+                self._session = None
+
+    async def notify(self, message: str, extra: Optional[Dict[str, Any]] = None) -> None:
+        if self._webhook_url is None:
+            logger.debug("Discord webhook URL not configured; skipping notification")
+            return
+        async with self._lock:
+            session = self._session
+        if session is None:
+            logger.warning("Discord session not ready; skipping notification")
+            return
+        payload: Dict[str, Any] = {"content": message}
+        if extra:
+            payload.update(extra)
+        try:
+            async with session.post(self._webhook_url, json=payload) as response:
+                if response.status >= 400:
+                    logger.warning(
+                        "Discord notification failed: status=%s body=%s",
+                        response.status,
+                        await response.text(),
+                    )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Discord notification exception: %s", exc)

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal, ROUND_DOWN
+
+
+def utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def parse_iso8601_z(value: str) -> datetime:
+    normalized = value.replace("Z", "+00:00")
+    dt = datetime.fromisoformat(normalized)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def quantize(value: float, step: float) -> float:
+    d_value = Decimal(str(value))
+    d_step = Decimal(str(step))
+    quantized = (d_value // d_step) * d_step
+    return float(quantized.quantize(d_step, rounding=ROUND_DOWN))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+pybotters==1.9.1
+aiohttp==3.11.18
+fastapi==0.115.0
+uvicorn==0.32.0
+pydantic==1.10.19
+loguru==0.7.2


### PR DESCRIPTION
## Summary
- add FastAPI application that validates TradingView webhook payloads and enforces idempotency/timestamp checks
- integrate a pybotters-backed GMO Coin service with retry logic and position polling for entry/close workflows
- provide optional Discord notifications plus health and status endpoints for monitoring

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68da0c7c704c8322a1966330d953e889